### PR TITLE
Fix positioning bug by adding missing v()

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -192,12 +192,14 @@ export default function handler(
   node.setPadding(Yoga.EDGE_RIGHT, style.paddingRight || 0)
 
   node.setPositionType(
-    (style.position,
-    {
-      absolute: Yoga.POSITION_TYPE_ABSOLUTE,
-      relative: Yoga.POSITION_TYPE_RELATIVE,
-    },
-    Yoga.POSITION_TYPE_RELATIVE)
+    v(
+      style.position,
+      {
+        absolute: Yoga.POSITION_TYPE_ABSOLUTE,
+        relative: Yoga.POSITION_TYPE_RELATIVE,
+      },
+      Yoga.POSITION_TYPE_RELATIVE
+    )
   )
 
   if (typeof style.top !== 'undefined') {


### PR DESCRIPTION
## Test

```js
<div
  style={{
    display: 'flex',
    height: '100%',
    width: '100%',
    alignItems: 'center',
    justifyContent: 'center',
    flexDirection: 'column',
  }}
>
  <div
    style={{
      width: 100,
      height: 100,
      backgroundColor: '#000',
    }}
  ></div>
  <div
    style={{
      left: 0,
      top: 0,
      width: 100,
      height: 100,
      position: 'absolute',
      backgroundColor: '#f00',
    }}
  ></div>
</div>
```

### Before

<img width="803" src="https://user-images.githubusercontent.com/992008/152642868-ac44526e-6e0b-4baf-b997-b1d1b4f0297d.png">

### After

<img width="801" src="https://user-images.githubusercontent.com/992008/152642873-66c6fc57-9f9a-45f5-a227-4de17e134fe0.png">