### PR TITLE
Basic text layout algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The image will be resized to the current font-size (both width and height), so i
 | `background-origin` | TBD |
 | `text-decoration` | TBD |
 | `transform-origin` | TBD |
+| `line-height` | TBD |
+| `white-space` | TBD |
 
 Note:
 

--- a/playground/pages/test.jsx
+++ b/playground/pages/test.jsx
@@ -47,6 +47,9 @@ const example_rauchg = (
     </div>
     <div
       style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
         padding: '20px 40px',
         letterSpacing: -2,
         fontSize: 40,
@@ -66,17 +69,77 @@ const example_rauchg = (
           'rotate(-10deg) translate(0, -10px) skewX(-10deg) scale(1.2, 1.2)',
       }}
     >
-      7 Principles of{' '}
+      7 Principles of
       <span
         style={{
+          margin: '0 10px',
           color: 'gold',
-          display: 'inline-block',
+          display: 'block',
           transform: 'rotate(10deg) scale(1, 2)',
         }}
       >
         Rich
-      </span>{' '}
+      </span>
       Web Applications
+    </div>
+  </div>
+)
+
+const example_text_layout = (
+  <div
+    style={{
+      display: 'flex',
+      height: '100%',
+      width: '100%',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row',
+      flexWrap: 'nowrap',
+    }}
+  >
+    <div
+      style={{
+        padding: 10,
+        textAlign: 'left',
+      }}
+    >
+      text-align: left. Lorem ipsum dolor sit amet consectetur adipisicing elit.
+      Animi natus doloribus unde eaque facere suscipit eum! Error, quidem
+      commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse pariatur
+      saepe praesentium.
+    </div>
+    <div
+      style={{
+        padding: 10,
+        textAlign: 'center',
+      }}
+    >
+      text-align: center. Lorem ipsum dolor sit amet consectetur adipisicing
+      elit. Animi natus doloribus unde eaque facere suscipit eum! Error, quidem
+      commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse pariatur
+      saepe praesentium.
+    </div>
+    <div
+      style={{
+        padding: 10,
+        textAlign: 'justify',
+      }}
+    >
+      text-align: jusitfy. Lorem ipsum dolor sit amet consectetur adipisicing
+      elit. Animi natus doloribus unde eaque facere suscipit eum! Error, quidem
+      commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse pariatur
+      saepe praesentium.
+    </div>
+    <div
+      style={{
+        padding: 10,
+        textAlign: 'right',
+      }}
+    >
+      text-align: right. Lorem ipsum dolor sit amet consectetur adipisicing
+      elit. Animi natus doloribus unde eaque facere suscipit eum! Error, quidem
+      commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse pariatur
+      saepe praesentium.
     </div>
   </div>
 )
@@ -259,7 +322,7 @@ export default function Playground() {
         fonts,
         graphemeImages,
         // embedFont: false,
-        // debug: true,
+        debug: true,
       })
 
       setSvg(result)
@@ -278,6 +341,8 @@ export default function Playground() {
           width,
           height,
           overflow: 'hidden',
+          letterSpacing: 0,
+          fontSize: 16,
         }}
       >
         {element}

--- a/src/font.ts
+++ b/src/font.ts
@@ -135,13 +135,9 @@ export default class FontLoader {
   ) {
     // console.log(font.charToGlyphIndex('✅') !== 0)
 
-    return {
-      width: font.getAdvanceWidth(content, fontSize, {
-        letterSpacing: letterSpacing / fontSize,
-      }),
-      ascent: (font.ascender / font.unitsPerEm) * fontSize,
-      descent: -(font.descender / font.unitsPerEm) * fontSize,
-    }
+    return font.getAdvanceWidth(content, fontSize, {
+      letterSpacing: letterSpacing / fontSize,
+    })
   }
 
   public getSVG(
@@ -167,16 +163,5 @@ export default class FontLoader {
         letterSpacing: letterSpacing / fontSize,
       })
       .toPathData(2)
-  }
-
-  public getAscent(
-    font: opentype.Font,
-    {
-      fontSize,
-    }: {
-      fontSize: number
-    }
-  ) {
-    return (font.ascender / font.unitsPerEm) * fontSize
   }
 }


### PR DESCRIPTION
Closes #6.

This PR implements the very basic text layout algorithm, which fixes the current flex behavior here: https://github.com/vercel/satori/issues/2#issuecomment-1031274360. 

The layout algorithm is simply O(n), and supports the 4 basic text alignments (Satori vs HTML):

<img width="651" alt="CleanShot 2022-02-08 at 17 44 31@2x" src="https://user-images.githubusercontent.com/3676859/153034865-eae088a2-a431-41c7-b07d-3c6b2bfbdf2c.png">

This also unblocks future work for ellipsis support and potentially #13.