### PR TITLE
Improve line breaking

### DIFF
--- a/playground/pages/test.jsx
+++ b/playground/pages/test.jsx
@@ -91,6 +91,7 @@ const example_text_layout = (
       display: 'flex',
       height: '100%',
       width: '100%',
+      padding: 20,
       alignItems: 'center',
       justifyContent: 'center',
       flexDirection: 'row',
@@ -231,7 +232,7 @@ export default function Playground() {
   repo = repo || 'next.js 🤯'
   subtitle = subtitle || 'the react framework ✨🥰'
 
-  const element = (
+  let element = (
     <div
       style={{
         fontFamily: 'Inter',
@@ -299,6 +300,8 @@ export default function Playground() {
       </div>
     </div>
   )
+
+  // element = example_text_layout
 
   useEffect(() => {
     ;(async () => {

--- a/src/text.ts
+++ b/src/text.ts
@@ -148,7 +148,14 @@ export default function* buildTextNodes(
           remainingSpaceWidth = 0
         }
 
-        if (currentWidth + remainingSpaceWidth + w > width) {
+        const allowedToPutAtBeginning =
+          remainingSpaceWidth || ',.!?:-@)>]}%#'.indexOf(word[0]) < 0
+        const allowedToJustify = !currentWidth || !!remainingSpaceWidth
+
+        if (
+          allowedToPutAtBeginning &&
+          currentWidth + remainingSpaceWidth + w > width
+        ) {
           // Start a new line, spaces can be ignored.
           lineWidth.push(currentWidth)
           lines.push(currentLine)
@@ -160,12 +167,17 @@ export default function* buildTextNodes(
           // It fits into the current line.
           currentLine += remainingSpace + word
           currentWidth += remainingSpaceWidth + w
-          lineSegmentNumber[lineSegmentNumber.length - 1]++
+          if (allowedToJustify) {
+            lineSegmentNumber[lineSegmentNumber.length - 1]++
+          }
         }
 
         remainingSpace = ''
         remainingSpaceWidth = 0
-        lineIndex++
+
+        if (allowedToJustify) {
+          lineIndex++
+        }
 
         maxWidth = Math.max(maxWidth, currentWidth)
         wordsInLayout[i] = {


### PR DESCRIPTION
There are some prohibition rules for line start in typesetting, this PR improves the behavior so symbols like `.` can't occur in the beginning of a line.

Also this fixes the justify behavior a bit too.

<img width="652" alt="CleanShot 2022-02-08 at 18 12 41@2x" src="https://user-images.githubusercontent.com/3676859/153040100-4d3937ca-5211-4e7a-a259-0a33bd4379a9.png">

