### PR TITLE
Add support `text-overflow: ellipsis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The image will be resized to the current font-size (both width and height), so i
 | `background-position` | Supported |
 | `background-size` | Support two-value size string such as `10px 20%` |
 | `white-space` | Support `normal` and `nowrap` |
+| `text-overflow` | Support `clip` and `ellipsis` |
 | `background-clip` | TBD |
 | `background-repeat` | TBD |
 | `background-origin` | TBD |

--- a/playground/cards/text-align.js
+++ b/playground/cards/text-align.js
@@ -23,9 +23,33 @@ export default (
           width: 60,
           padding: 5,
           border: '1px solid',
+          marginRight: 20,
         }}
       >
-        Hello, world!!!!
+        Hello, world!!!! Satori is a library.
+      </div>
+      <div
+        style={{
+          width: 60,
+          padding: 5,
+          border: '1px solid',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          marginRight: 20,
+        }}
+      >
+        Hello, world!!!! Satori is a library.
+      </div>
+      <div
+        style={{
+          width: 40,
+          padding: 5,
+          border: '1px solid',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        Hello, world!!!! Satori is a library.
       </div>
       <div style={{ width: 20 }} />
       <div
@@ -60,6 +84,19 @@ export default (
         }}
       >
         Hello, world!!!!
+      </div>
+      <div style={{ width: 20 }} />
+      <div
+        style={{
+          padding: 5,
+          maxWidth: 60,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          border: '1px solid',
+        }}
+      >
+        Hey, Satori.
       </div>
     </div>
     <div

--- a/playground/pages/test.jsx
+++ b/playground/pages/test.jsx
@@ -10,7 +10,7 @@ import rauchgCard from '../cards/rauchg'
 import overflowCard from '../cards/overflow'
 import getTwemojiMap, { loadEmoji } from '../utils/twemoji'
 
-const card = overflowCard
+const card = textAlignCard
 
 async function init() {
   if (typeof window === 'undefined') return []
@@ -92,7 +92,7 @@ export default function Playground() {
   }, [])
 
   return (
-    <div id='container'>
+    <div id='container' style={{ padding: 10 }}>
       <div id='svg' dangerouslySetInnerHTML={{ __html: svg }}></div>
       <div
         style={{


### PR DESCRIPTION
This feature is important for displaying highly dynamic content or user input. Preview (Satori vs Chrome): 

<img width="811" alt="CleanShot 2022-03-05 at 02 14 19@2x" src="https://user-images.githubusercontent.com/3676859/156861497-afffd111-43ef-4502-95ab-3932c64c8705.png">
