### PR TITLE
Add support for `text-decoration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ The image will be resized to the current font-size (both width and height), so i
 | `background-size` | Support two-value size string such as `10px 20%` |
 | `white-space` | Support `normal`, `pre`, `pre-wrap` and `nowrap` |
 | `text-overflow` | Support `clip` and `ellipsis` |
+| `text-decoration` | Support line types `underline` and `line-through`, and styles `dotted`, `dashed`, `solid` |
 | `line-height` | Supported |
 | `background-clip` | Support `border-box` and `text` |
 | `background-repeat` | TBD |
 | `background-origin` | TBD |
-| `text-decoration` | TBD |
 
 Note:
 

--- a/playground/cards/text-align.js
+++ b/playground/cards/text-align.js
@@ -16,6 +16,8 @@ export default (
         flexDirection: 'row',
         flexWrap: 'nowrap',
         backgroundColor: 'white',
+        textDecoration: 'underline',
+        color: 'crimson',
       }}
     >
       <div
@@ -117,6 +119,7 @@ export default (
           padding: 10,
           textAlign: 'left',
           lineHeight: '1em',
+          textDecoration: 'line-through yellow',
         }}
       >
         text-align: left. Lorem ipsum dolor sit amet consectetur adipisicing
@@ -129,6 +132,7 @@ export default (
           padding: 10,
           textAlign: 'center',
           lineHeight: '19px',
+          textDecoration: 'underline dashed crimson',
         }}
       >
         text-align: center. Lorem ipsum dolor sit amet consectetur adipisicing
@@ -141,6 +145,7 @@ export default (
           padding: 10,
           textAlign: 'justify',
           lineHeight: 1.4,
+          textDecoration: 'underline dotted blue',
         }}
       >
         text-align: jusitfy. Lorem ipsum dolor sit amet consectetur adipisicing
@@ -153,6 +158,7 @@ export default (
           padding: 10,
           textAlign: 'right',
           lineHeight: '160%',
+          textDecoration: 'underline solid black',
         }}
       >
         text-align: right. Lorem ipsum dolor sit amet consectetur adipisicing

--- a/src/builder/text-decoration.ts
+++ b/src/builder/text-decoration.ts
@@ -1,0 +1,56 @@
+import { buildXMLString } from 'src/utils'
+
+export default function decoration(
+  {
+    width,
+    left,
+    top,
+    ascender,
+    clipPathId,
+  }: {
+    width: number
+    left: number
+    top: number
+    ascender: number
+    clipPathId?: string
+  },
+  style: Record<string, any>
+) {
+  const {
+    textDecorationColor,
+    textDecorationStyle,
+    textDecorationLine,
+    fontSize,
+  } = style
+  if (!textDecorationLine || textDecorationLine === 'none') return ''
+
+  // The UA should use such font-based information when choosing auto line thicknesses wherever appropriate.
+  // https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness
+  const height = Math.max(1, fontSize * 0.1)
+
+  const y =
+    textDecorationLine === 'line-through'
+      ? top + ascender * 0.75
+      : textDecorationLine === 'underline'
+      ? top + ascender * 1.25
+      : top
+
+  const dasharray =
+    textDecorationStyle === 'dashed'
+      ? `${height * 1.2} ${height * 2}`
+      : textDecorationStyle === 'dotted'
+      ? `0 ${height * 2}`
+      : undefined
+
+  return buildXMLString('line', {
+    x1: left,
+    y1: y,
+    x2: left + width,
+    y2: y,
+    stroke: textDecorationColor,
+    'stroke-width': height,
+    'stroke-dasharray': dasharray,
+    'stroke-linecap': textDecorationStyle === 'dotted' ? 'round' : 'square',
+    'clip-path': clipPathId ? `url(#${clipPathId})` : undefined,
+  })
+}

--- a/src/builder/text.ts
+++ b/src/builder/text.ts
@@ -68,7 +68,7 @@ export default function text(
     matrix: string
     opacity: number
     image: string | null
-    clipPathId?: number
+    clipPathId?: string
     debug?: boolean
     shape?: boolean
   },

--- a/src/handler/inheritable.ts
+++ b/src/handler/inheritable.ts
@@ -5,16 +5,19 @@ const list = new Set([
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'letterSpacing',
   'lineHeight',
   'textAlign',
   'textTransform',
-  'whiteSpace',
-  'letterSpacing',
-  'transform',
-  'wordBreak',
   'textShadowOffset',
   'textShadowColor',
   'textShadowRadius',
+  'textDecorationLine',
+  'textDecorationStyle',
+  'textDecorationColor',
+  'whiteSpace',
+  'transform',
+  'wordBreak',
 
   // Special case: SVG doesn't apply opacity to children elements so we need to
   // make it inheritable here.


### PR DESCRIPTION
Support line types `underline` and `line-through`, and styles `dotted`, `dashed`, `solid`.

Also fixed a bug that `border` doesn't use `color` but black as its fallback.

<img width="649" alt="CleanShot 2022-03-18 at 21 30 27@2x" src="https://user-images.githubusercontent.com/3676859/159079052-bc305217-4234-4682-b99d-b1c48c16d0f5.png">
