### PR TITLE
Fix unmatched zh/ja symbols

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -15,7 +15,7 @@
 // - https://fonts.google.com/noto/fonts?sort=popularity&noto.query=sans
 const code = {
   emoji: /\p{Emoji_Presentation}/u,
-  ja: /\p{scx=Hira}|\p{scx=Kana}/u,
+  ja: /\p{scx=Hira}|\p{scx=Kana}|[，；：]/u,
   ko: /\p{scx=Hangul}/u,
   zh: /\p{scx=Han}/u,
   th: /\p{scx=Thai}/u,


### PR DESCRIPTION
Currently common full-width punctuations such as `，；：` are missing from the matches, which results in error with Google Fonts. This is more like a manual fix until we find a better way.