### PR TITLE
Add engines node >=16 to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "css-to-react-native": "^3.0.0",
     "postcss-value-parser": "^4.2.0",
     "yoga-layout-prebuilt": "^1.10.0"
+  },
+  "engines": {
+    "node": ">=16"
   }
 }


### PR DESCRIPTION
This ensure the consumer is aware that Node.js 16 or newer is necessary. Older versions print this error:
```
WebAssembly.compile(): Compiling function #11 failed: invalid value type 'Simd128'
```