### PR TITLE
Fix absolute positioning bug

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -146,10 +146,6 @@ export default function* layout(
   // 3. Post-process the node.
   const [x, y] = yield
 
-  if (computedStyle.position === 'absolute') {
-    node.calculateLayout()
-  }
-
   let { left, top, width, height } = node.getComputedLayout()
 
   // Attach offset to the current node.

--- a/test/position.test.tsx
+++ b/test/position.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { it, describe, expect } from 'vitest'
+
+import { initFonts } from './utils'
+import satori from '../src'
+
+describe('Position', () => {
+  let fonts
+  initFonts((f) => (fonts = f))
+
+  describe('absolute', () => {
+    it('should support absolute position', async () => {
+      const svg = await satori(
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              right: 0,
+              width: 10,
+              height: 10,
+              background: 'black',
+            }}
+          ></div>
+        </div>,
+        { width: 100, height: 100, fonts }
+      )
+      expect(svg).toMatchInlineSnapshot(
+        '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"90\\" y=\\"90\\" width=\\"10\\" height=\\"10\\" fill=\\"black\\"/></svg>"'
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #64.

Test case:

```jsx
<div
  style={{
    backgroundColor: 'white',
    height: '100%',
    width: '100%',
  }}
>
  <div
    style={{
      position: 'absolute',
      bottom: 0,
      right: 0,
    }}
  >
    Vercel
  </div>
</div>
```

Old:

![image](https://user-images.githubusercontent.com/3676859/183915451-186a27b1-92fb-467f-89b0-b8d032be5360.png)

Fix:

![image](https://user-images.githubusercontent.com/3676859/183915370-a2eb0974-ff04-43d8-9fb1-1a80b05e5760.png)
