### PR TITLE
Fix typo: "langauge" => "language"

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -7,7 +7,7 @@
 // - https://unicode.org/reports/tr18/#General_Category_Property
 // - https://tc39.es/ecma262/multipage/text-processing.html#table-unicode-script-values
 
-// Supported langauges. The order matters.
+// Supported languages. The order matters.
 // Usually, this is only for "special cases" like CJKV languages as latin
 // characters are usually included in the base font, and can be safely fallback
 // to the Noto Sans font. A list of special cases we want to support can be

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -85,14 +85,14 @@ export default async function satori(
         new Set(segment(segmentsMissingFont.join(''), 'grapheme'))
       )
 
-      const langaugeCodes: Record<string, string[]> = {}
+      const languageCodes: Record<string, string[]> = {}
       segmentsMissingFont.forEach((seg) => {
         const code = detectLanguageCode(seg)
-        langaugeCodes[code] = langaugeCodes[code] || []
+        languageCodes[code] = languageCodes[code] || []
         if (code === 'emoji') {
-          langaugeCodes[code].push(seg)
+          languageCodes[code].push(seg)
         } else {
-          langaugeCodes[code][0] = (langaugeCodes[code][0] || '') + seg
+          languageCodes[code][0] = (languageCodes[code][0] || '') + seg
         }
       })
 
@@ -100,7 +100,7 @@ export default async function satori(
       const images: Record<string, string> = {}
 
       await Promise.all(
-        Object.entries(langaugeCodes).flatMap(([code, segments]) =>
+        Object.entries(languageCodes).flatMap(([code, segments]) =>
           segments.map((segment) =>
             options.loadAdditionalAsset(code, segment).then((asset) => {
               if (typeof asset === 'string') {


### PR DESCRIPTION
This PR fixes a typo in a variable and comment. 

"langauge"  should be "language"