### PR TITLE
Throw error if div has children but not `display:flex`

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -173,7 +173,7 @@ export default function* layout(
     )
   } else {
     const display = style?.display ?? 'block'
-    if (type === 'div' && children && display !== 'flex' && display !== 'none') {
+    if (type === 'div' && Array.isArray(children) && display !== 'flex' && display !== 'none') {
       throw new Error(`Expected <div> to have style={{display: 'flex'}} but received style={{display: '${display}'}}`)
     }
     baseRenderResult = rect(

--- a/test/units.test.tsx
+++ b/test/units.test.tsx
@@ -200,5 +200,4 @@ describe('Units', () => {
     expect(typeof svg).toBe('string');
   })
 
-  
 })


### PR DESCRIPTION
- FIxes #81 
