### PR TITLE
Fix JSX traversal

### DIFF
--- a/playground/cards/data.js
+++ b/playground/cards/data.js
@@ -1,4 +1,21 @@
 export default {
+  helloworld: `<div
+  style={{
+    height: '100%',
+    width: '100%',
+    fontSize: 60,
+    fontWeight: 600,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'white',
+  }}
+>
+  <div>Hello</div>
+  <div>Satori</div>
+</div>
+`,
   Rauchg: `<div
   style={{
     display: 'flex',
@@ -135,178 +152,178 @@ export default {
     Ship
   </div>
 </div>`,
-  Text: `<div
-  style={{
-    display: 'flex',
-    width: '100%',
-    height: '100%',
-    flexDirection: 'column',
-    fontFamily: 'Inter',
-    flexWrap: 'nowrap',
-    backgroundColor: 'white',
-  }}
->
-  <div
-    style={{
-      display: 'flex',
-      width: '100%',
-      padding: 10,
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'row',
-      flexWrap: 'nowrap',
-      textDecoration: 'underline',
-      color: 'crimson',
-    }}
-  >
-    <div
-      style={{
-        width: 60,
-        padding: 5,
-        border: '1px solid',
-        marginRight: 20,
-      }}
-    >
-      Hello, world!!!! Satori is a library.
-    </div>
-    <div
-      style={{
-        width: 60,
-        padding: 5,
-        border: '1px solid',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        marginRight: 20,
-      }}
-    >
-      Hello, world!!!! Satori is a library.
-    </div>
-    <div
-      style={{
-        width: 40,
-        padding: 5,
-        border: '1px solid',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      }}
-    >
-      Hello, world!!!! Satori is a library.
-    </div>
-    <div style={{ width: 20 }} />
-    <div
-      style={{
-        width: 60,
-        padding: 5,
-        whiteSpace: 'nowrap',
-        border: '1px solid',
-      }}
-    >
-      Hello, world!!!!
-    </div>
-    <div style={{ width: 60 }} />
-    <div
-      style={{
-        padding: 5,
-        maxWidth: 60,
-        whiteSpace: 'nowrap',
-        border: '1px solid',
-      }}
-    >
-      Hello, world!!!!
-    </div>
-    <div style={{ width: 60 }} />
-    <div
-      style={{
-        padding: 5,
-        maxWidth: 60,
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        border: '1px solid',
-      }}
-    >
-      Hello, world!!!!
-    </div>
-    <div style={{ width: 20 }} />
-    <div
-      style={{
-        padding: 5,
-        maxWidth: 60,
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        border: '1px solid',
-      }}
-    >
-      Hey, Satori.
-    </div>
-  </div>
-  <div
-    style={{
-      display: 'flex',
-      width: '100%',
-      padding: 10,
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'row',
-      flexWrap: 'nowrap',
-    }}
-  >
-    <div>Hello, world!!!!</div>
-    <div
-      style={{
-        padding: 10,
-        textAlign: 'left',
-        lineHeight: '1em',
-        textDecoration: 'line-through yellow',
-      }}
-    >
-      text-align: left. Lorem ipsum dolor sit amet consectetur adipisicing
-      elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
-      quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
-      pariatur saepe praesentium.
-    </div>
-    <div
-      style={{
-        padding: 10,
-        textAlign: 'center',
-        lineHeight: '19px',
-        textDecoration: 'underline dashed crimson',
-      }}
-    >
-      text-align: center. Lorem ipsum dolor sit amet consectetur adipisicing
-      elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
-      quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
-      pariatur saepe praesentium.
-    </div>
-    <div
-      style={{
-        padding: 10,
-        textAlign: 'justify',
-        lineHeight: 1.4,
-        textDecoration: 'underline dotted blue',
-      }}
-    >
-      text-align: jusitfy. Lorem ipsum dolor sit amet consectetur adipisicing
-      elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
-      quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
-      pariatur saepe praesentium.
-    </div>
-    <div
-      style={{
-        padding: 10,
-        textAlign: 'right',
-        lineHeight: '160%',
-        textDecoration: 'underline solid black',
-      }}
-    >
-      text-align: right. Lorem ipsum dolor sit amet consectetur adipisicing
-      elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
-      quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
-      pariatur saepe praesentium.
-    </div>
-  </div>
-</div>`,
-  Fonts: `<div
+  //   Text: `<div
+  //   style={{
+  //     display: 'flex',
+  //     width: '100%',
+  //     height: '100%',
+  //     flexDirection: 'column',
+  //     fontFamily: 'Inter',
+  //     flexWrap: 'nowrap',
+  //     backgroundColor: 'white',
+  //   }}
+  // >
+  //   <div
+  //     style={{
+  //       display: 'flex',
+  //       width: '100%',
+  //       padding: 10,
+  //       alignItems: 'center',
+  //       justifyContent: 'center',
+  //       flexDirection: 'row',
+  //       flexWrap: 'nowrap',
+  //       textDecoration: 'underline',
+  //       color: 'crimson',
+  //     }}
+  //   >
+  //     <div
+  //       style={{
+  //         width: 60,
+  //         padding: 5,
+  //         border: '1px solid',
+  //         marginRight: 20,
+  //       }}
+  //     >
+  //       Hello, world!!!! Satori is a library.
+  //     </div>
+  //     <div
+  //       style={{
+  //         width: 60,
+  //         padding: 5,
+  //         border: '1px solid',
+  //         overflow: 'hidden',
+  //         textOverflow: 'ellipsis',
+  //         marginRight: 20,
+  //       }}
+  //     >
+  //       Hello, world!!!! Satori is a library.
+  //     </div>
+  //     <div
+  //       style={{
+  //         width: 40,
+  //         padding: 5,
+  //         border: '1px solid',
+  //         overflow: 'hidden',
+  //         textOverflow: 'ellipsis',
+  //       }}
+  //     >
+  //       Hello, world!!!! Satori is a library.
+  //     </div>
+  //     <div style={{ width: 20 }} />
+  //     <div
+  //       style={{
+  //         width: 60,
+  //         padding: 5,
+  //         whiteSpace: 'nowrap',
+  //         border: '1px solid',
+  //       }}
+  //     >
+  //       Hello, world!!!!
+  //     </div>
+  //     <div style={{ width: 60 }} />
+  //     <div
+  //       style={{
+  //         padding: 5,
+  //         maxWidth: 60,
+  //         whiteSpace: 'nowrap',
+  //         border: '1px solid',
+  //       }}
+  //     >
+  //       Hello, world!!!!
+  //     </div>
+  //     <div style={{ width: 60 }} />
+  //     <div
+  //       style={{
+  //         padding: 5,
+  //         maxWidth: 60,
+  //         whiteSpace: 'nowrap',
+  //         overflow: 'hidden',
+  //         border: '1px solid',
+  //       }}
+  //     >
+  //       Hello, world!!!!
+  //     </div>
+  //     <div style={{ width: 20 }} />
+  //     <div
+  //       style={{
+  //         padding: 5,
+  //         maxWidth: 60,
+  //         whiteSpace: 'nowrap',
+  //         overflow: 'hidden',
+  //         textOverflow: 'ellipsis',
+  //         border: '1px solid',
+  //       }}
+  //     >
+  //       Hey, Satori.
+  //     </div>
+  //   </div>
+  //   <div
+  //     style={{
+  //       display: 'flex',
+  //       width: '100%',
+  //       padding: 10,
+  //       alignItems: 'center',
+  //       justifyContent: 'center',
+  //       flexDirection: 'row',
+  //       flexWrap: 'nowrap',
+  //     }}
+  //   >
+  //     <div>Hello, world!!!!</div>
+  //     <div
+  //       style={{
+  //         padding: 10,
+  //         textAlign: 'left',
+  //         lineHeight: '1em',
+  //         textDecoration: 'line-through yellow',
+  //       }}
+  //     >
+  //       text-align: left. Lorem ipsum dolor sit amet consectetur adipisicing
+  //       elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
+  //       quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
+  //       pariatur saepe praesentium.
+  //     </div>
+  //     <div
+  //       style={{
+  //         padding: 10,
+  //         textAlign: 'center',
+  //         lineHeight: '19px',
+  //         textDecoration: 'underline dashed crimson',
+  //       }}
+  //     >
+  //       text-align: center. Lorem ipsum dolor sit amet consectetur adipisicing
+  //       elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
+  //       quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
+  //       pariatur saepe praesentium.
+  //     </div>
+  //     <div
+  //       style={{
+  //         padding: 10,
+  //         textAlign: 'justify',
+  //         lineHeight: 1.4,
+  //         textDecoration: 'underline dotted blue',
+  //       }}
+  //     >
+  //       text-align: jusitfy. Lorem ipsum dolor sit amet consectetur adipisicing
+  //       elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
+  //       quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
+  //       pariatur saepe praesentium.
+  //     </div>
+  //     <div
+  //       style={{
+  //         padding: 10,
+  //         textAlign: 'right',
+  //         lineHeight: '160%',
+  //         textDecoration: 'underline solid black',
+  //       }}
+  //     >
+  //       text-align: right. Lorem ipsum dolor sit amet consectetur adipisicing
+  //       elit. Animi natus doloribus unde eaque facere suscipit eum! Error,
+  //       quidem commodi suscipit eos expedita repellendus fuga. Officia, ut! Esse
+  //       pariatur saepe praesentium.
+  //     </div>
+  //   </div>
+  // </div>`,
+  'Font & Emoji': `<div
   style={{
     display: 'flex',
     height: '100%',
@@ -361,6 +378,7 @@ export default {
   </div>
   <div
     style={{
+      display: 'flex',
       fontFamily: 'Inter',
       fontSize: 40,
       fontStyle: 'normal',

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -82,7 +82,7 @@ export default async function* layout(
 
   // Process as element.
   const { type, props } = element
-  const { style, children } = props
+  const { style, children } = props || {}
 
   const node = Yoga.Node.create()
   parent.insertChild(node, parent.getChildCount())
@@ -121,7 +121,7 @@ export default async function* layout(
 
   // 2. Do layout recursively for its children.
   const normalizedChildren =
-    typeof children === 'undefined' ? [] : [].concat(children)
+    typeof children === 'undefined' ? [] : [].concat(children).flat(Infinity)
   const iterators: ReturnType<typeof layout>[] = []
 
   let i = 0

--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -88,44 +88,31 @@ describe('Basic', () => {
     )
   })
 
-  it('should support border radius', async () => {
+  it('should support array in JSX children', async () => {
     const svg = await satori(
       <div
         style={{
-          borderRadius: '10px',
-          background: 'red',
+          backgroundColor: '#ff0',
           width: '100%',
           height: '100%',
+          display: 'flex',
         }}
-      ></div>,
+      >
+        <div>1</div>
+        {[
+          <div style={{ display: 'flex' }}>2{[<div>3</div>]}</div>,
+          <div style={{ display: 'flex' }}>{[4]}</div>,
+        ]}
+      </div>,
       {
         width: 100,
         height: 100,
+        embedFont: false,
         fonts,
       }
     )
     expect(svg).toMatchInlineSnapshot(
-      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"red\\" d=\\"M10,0 h80 a10,10 0 0 1 10,10 v80 a10,10 0 0 1 -10,10 h-80 a10,10 0 0 1 -10,-10 v-80 a10,10 0 0 1 10,-10\\"/></svg>"'
-    )
-  })
-
-  it('should support border width and color', async () => {
-    const svg = await satori(
-      <div
-        style={{
-          border: '1px solid',
-          width: '100%',
-          height: '100%',
-        }}
-      ></div>,
-      {
-        width: 100,
-        height: 100,
-        fonts,
-      }
-    )
-    expect(svg).toMatchInlineSnapshot(
-      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><defs><clipPath id=\\"satori_bc-id\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\"/></clipPath></defs><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"transparent\\" stroke=\\"black\\" stroke-width=\\"2\\" clip-path=\\"url(#satori_bc-id)\\"/></svg>"'
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"#ff0\\"/><text x=\\"0\\" y=\\"15.48289183222958\\" width=\\"8.984375\\" height=\\"18.75\\" font-weight=\\"normal\\" font-style=\\"normal\\" font-size=\\"16\\" font-family=\\"serif\\" fill=\\"black\\">1</text><text x=\\"9\\" y=\\"15.48289183222958\\" width=\\"8.984375\\" height=\\"18.75\\" font-weight=\\"normal\\" font-style=\\"normal\\" font-size=\\"16\\" font-family=\\"serif\\" fill=\\"black\\">2</text><text x=\\"18\\" y=\\"15.48289183222958\\" width=\\"8.984375\\" height=\\"18.75\\" font-weight=\\"normal\\" font-style=\\"normal\\" font-size=\\"16\\" font-family=\\"serif\\" fill=\\"black\\">3</text><text x=\\"27\\" y=\\"15.48289183222958\\" width=\\"8.984375\\" height=\\"18.75\\" font-weight=\\"normal\\" font-style=\\"normal\\" font-size=\\"16\\" font-family=\\"serif\\" fill=\\"black\\">4</text></svg>"'
     )
   })
 })

--- a/test/border.test.tsx
+++ b/test/border.test.tsx
@@ -8,6 +8,47 @@ describe('Border', () => {
   let fonts
   initFonts((f) => (fonts = f))
 
+  it('should support border radius', async () => {
+    const svg = await satori(
+      <div
+        style={{
+          borderRadius: '10px',
+          background: 'red',
+          width: '100%',
+          height: '100%',
+        }}
+      ></div>,
+      {
+        width: 100,
+        height: 100,
+        fonts,
+      }
+    )
+    expect(svg).toMatchInlineSnapshot(
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"red\\" d=\\"M10,0 h80 a10,10 0 0 1 10,10 v80 a10,10 0 0 1 -10,10 h-80 a10,10 0 0 1 -10,-10 v-80 a10,10 0 0 1 10,-10\\"/></svg>"'
+    )
+  })
+
+  it('should support border width and color', async () => {
+    const svg = await satori(
+      <div
+        style={{
+          border: '1px solid',
+          width: '100%',
+          height: '100%',
+        }}
+      ></div>,
+      {
+        width: 100,
+        height: 100,
+        fonts,
+      }
+    )
+    expect(svg).toMatchInlineSnapshot(
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><defs><clipPath id=\\"satori_bc-id\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\"/></clipPath></defs><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"transparent\\" stroke=\\"black\\" stroke-width=\\"2\\" clip-path=\\"url(#satori_bc-id)\\"/></svg>"'
+    )
+  })
+
   describe('border-color', () => {
     it('should render black border by default', async () => {
       const svg = await satori(


### PR DESCRIPTION
Fixes a bug where there can be multiple array in the JSX children in any depth. Test case that fails in current prod:

```jsx
<div style={{display: 'flex',color: 'white'}}>
  <div>Develop</div>
  {[<div>hi</div>]}
</div>
```

Also polished a bit on the playground examples, commented out the typography one as it's more for testing but not a good showcase.