### PR TITLE
Fix SVG scaling

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -41,8 +41,26 @@ export default function handler(
   if (type === 'svg') {
     const viewBox = props.viewBox || props.viewbox
     const viewBoxSize = viewBox.split(' ').map((v) => parseInt(v, 10))
-    const width = props.width || viewBoxSize[2] || 0
-    const height = props.height || viewBoxSize[3] || 0
+    const ratio = viewBoxSize[3] / viewBoxSize[2]
+
+    let { width, height } = props
+    if (typeof width === 'undefined' && height) {
+      if (typeof height === 'string' && height.endsWith('%')) {
+        width = parseInt(height) / ratio + '%'
+      } else {
+        width = parseInt(height) / ratio
+      }
+    } else if (typeof height === 'undefined' && width) {
+      if (typeof width === 'string' && width.endsWith('%')) {
+        height = parseInt(width) * ratio + '%'
+      } else {
+        height = parseInt(width) * ratio
+      }
+    } else {
+      width ||= viewBoxSize[2]
+      height ||= viewBoxSize[3]
+    }
+
     if (!style.width) style.width = width
     if (!style.height) style.height = height
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -302,10 +302,25 @@ function translateSVGNodeToSVGString(
 }
 
 export function SVGNodeToImage(node: ReactElement): string {
-  let { className, style, children, ...restProps } = node.props || {}
+  let {
+    viewBox,
+    viewbox,
+    width,
+    height,
+    className,
+    style,
+    children,
+    ...restProps
+  } = node.props || {}
+
+  viewBox ||= viewbox
+  const viewBoxSize = viewBox.split(' ').map((v) => parseInt(v, 10))
 
   // We directly assign the xmlns attribute here to deduplicate.
   restProps.xmlns = 'http://www.w3.org/2000/svg'
+  restProps.viewBox = viewBox
+  restProps.width = viewBoxSize[2]
+  restProps.height = viewBoxSize[3]
 
   return `data:image/svg+xml;utf8,${`<svg${Object.entries(restProps)
     .map(([k, v]) => {

--- a/test/svg.test.tsx
+++ b/test/svg.test.tsx
@@ -32,7 +32,7 @@ describe('SVG', () => {
       { width: 100, height: 100, fonts }
     )
     expect(svg).toMatchInlineSnapshot(
-      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"blue\\"/><image x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" href=\\"data:image/svg+xml;utf8,%3Csvg viewbox=%220 0 100 100%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2210%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22%3E%3C/circle%3E%3C/svg%3E\\" preserveAspectRatio=\\"none\\"/></svg>"'
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"blue\\"/><image x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" href=\\"data:image/svg+xml;utf8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewbox=%220 0 100 100%22 width=%22100%22 height=%22100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2210%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22%3E%3C/circle%3E%3C/svg%3E\\" preserveAspectRatio=\\"none\\"/></svg>"'
     )
   })
 
@@ -64,7 +64,40 @@ describe('SVG', () => {
       { width: 100, height: 100, fonts }
     )
     expect(svg).toMatchInlineSnapshot(
-      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"blue\\"/><image x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" href=\\"data:image/svg+xml;utf8,%3Csvg viewbox=%220 0 100 100%22 fill=%22yellow%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2210%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22%3E%3C/circle%3E%3C/svg%3E\\" preserveAspectRatio=\\"none\\"/></svg>"'
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"blue\\"/><image x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" href=\\"data:image/svg+xml;utf8,%3Csvg fill=%22yellow%22 xmlns=%22http://www.w3.org/2000/svg%22 viewbox=%220 0 100 100%22 width=%22100%22 height=%22100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2210%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22%3E%3C/circle%3E%3C/svg%3E\\" preserveAspectRatio=\\"none\\"/></svg>"'
+    )
+  })
+
+  it('should render svg size correctly', async () => {
+    const svg = await satori(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: 'blue',
+          display: 'flex',
+        }}
+      >
+        <svg
+          width='100'
+          viewBox='0 0 10 10'
+          fill='yellow'
+          xmlns='http://www.w3.org/2000/svg'
+        >
+          <circle
+            cx='5'
+            cy='5'
+            r='4'
+            stroke='black'
+            strokeWidth='3'
+            fill='red'
+          />
+        </svg>
+      </div>,
+      { width: 100, height: 100, fonts }
+    )
+    expect(svg).toMatchInlineSnapshot(
+      '"<svg width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\" xmlns=\\"http://www.w3.org/2000/svg\\"><rect x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" fill=\\"blue\\"/><image x=\\"0\\" y=\\"0\\" width=\\"100\\" height=\\"100\\" href=\\"data:image/svg+xml;utf8,%3Csvg fill=%22yellow%22 xmlns=%22http://www.w3.org/2000/svg%22 viewbox=%220 0 10 10%22 width=%2210%22 height=%2210%22%3E%3Ccircle cx=%225%22 cy=%225%22 r=%224%22 stroke=%22black%22 stroke-width=%223%22 fill=%22red%22%3E%3C/circle%3E%3C/svg%3E\\" preserveAspectRatio=\\"none\\"/></svg>"'
     )
   })
 })


### PR DESCRIPTION
Related to #101, this PR makes sure that the SVG will be scaled by ratio if only one of `width` and `height` attribute is specified.