### PR TITLE
Bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development tsup src/index.ts --watch --ignore-watch playground",
+    "dev:wasm": "WASM=1 NODE_ENV=development tsup src/index.ts --watch --ignore-watch playground",
     "build": "NODE_ENV=production pnpm run test && pnpm run build:default && pnpm run build:wasm",
     "build:default": "tsup",
     "build:wasm": "WASM=1 tsup",

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,8 +3,7 @@
     "dev": "next",
     "debug": "node --inspect node_modules/next/dist/bin/next",
     "build": "next build",
-    "start": "next start",
-    "postinstall": "cp node_modules/yoga-wasm-web/dist/yoga.wasm public/"
+    "start": "next start"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.4.5",
@@ -17,6 +16,6 @@
     "react-hot-toast": "^2.3.0",
     "react-live": "^2.4.1",
     "satori": "workspace:*",
-    "yoga-wasm-web": "^0.0.8"
+    "yoga-wasm-web": "0.1.2"
   }
 }

--- a/playground/pages/index.jsx
+++ b/playground/pages/index.jsx
@@ -1,4 +1,4 @@
-import satori from 'satori'
+import satori, { init as initSatori } from 'satori/wasm'
 import { LiveProvider, LiveContext, withLive } from 'react-live'
 import { useEffect, useState, useRef, useContext } from 'react'
 import { createPortal } from 'react-dom'
@@ -8,6 +8,7 @@ import toast, { Toaster } from 'react-hot-toast'
 import copy from 'copy-to-clipboard'
 import packageJson from 'satori/package.json'
 import * as resvg from '@resvg/resvg-wasm'
+import { initStreaming } from 'yoga-wasm-web'
 
 import { loadEmoji, getIconCode } from '../utils/twemoji'
 
@@ -25,6 +26,13 @@ const languageFontMap = {
   ja: 'Noto+Sans+JP',
   ko: 'Noto+Sans+KR',
   th: 'Noto+Sans+Thai',
+  he: 'Noto+Sans+Hebrew',
+  ar: 'Noto+Sans+Arabic',
+  bn: 'Noto+Sans+Bengali',
+  ta: 'Noto+Sans+Tamil',
+  te: 'Noto+Sans+Telugu',
+  ml: 'Noto+Sans+Malayalam',
+  devanagari: 'Noto+Sans+Devanagari',
   unknown: 'Noto+Sans',
 }
 
@@ -106,12 +114,15 @@ const spinner = (
 async function init() {
   if (typeof window === 'undefined') return []
 
-  const [_, font, fontBold, fontIcon] =
+  const [_, __, font, fontBold, fontIcon] =
     window.__resource ||
     (window.__resource = await Promise.all([
       fetch(
         'https://unpkg.com/@resvg/resvg-wasm@2.0.0-alpha.4/index_bg.wasm'
       ).then((res) => resvg.initWasm(res)),
+      fetch('https://unpkg.com/yoga-wasm-web@0.1.2/dist/yoga.wasm')
+        .then((res) => initStreaming(res))
+        .then((yoga) => initSatori(yoga)),
       ...(
         await Promise.all([
           fetch(

--- a/playground/styles.css
+++ b/playground/styles.css
@@ -94,7 +94,7 @@ code {
   padding: 4px 8px;
   gap: 8px;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 }
 .editor .editor-controls button {
   font-family: var(--font);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       react-hot-toast: ^2.3.0
       react-live: ^2.4.1
       satori: workspace:*
-      yoga-wasm-web: ^0.0.8
+      yoga-wasm-web: 0.1.2
     dependencies:
       '@monaco-editor/react': 4.4.5_sfoxds7t5ydpegc3knd667wn6m
       '@resvg/resvg-js': 1.4.0
@@ -59,7 +59,7 @@ importers:
       react-hot-toast: 2.3.0_sfoxds7t5ydpegc3knd667wn6m
       react-live: 2.4.1_sfoxds7t5ydpegc3knd667wn6m
       satori: link:..
-      yoga-wasm-web: 0.0.8
+      yoga-wasm-web: 0.1.2
 
 packages:
 
@@ -1837,6 +1837,6 @@ packages:
       '@types/yoga-layout': 1.9.2
     dev: false
 
-  /yoga-wasm-web/0.0.8:
-    resolution: {integrity: sha512-AFcRBnFk24jhNwjkT+wIc3+RgN3jv5czBjA4lsFd9rrnZ28cnEdevOpHH8Qa8BVPNKbgJPj5gHJdnqUHy+C0KQ==}
+  /yoga-wasm-web/0.1.2:
+    resolution: {integrity: sha512-8SkgawHcA0RUbMrnhxbaQkZDBi8rMed8pQHixkFF9w32zGhAwZ9/cOHWlpYfr6RCx42Yp3siV45/jPEkJxsk6w==}
     dev: false

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -152,10 +152,6 @@ export default async function* layout(
   // 3. Post-process the node.
   const [x, y] = yield
 
-  if (computedStyle.position === 'absolute') {
-    node.calculateLayout()
-  }
-
   let { left, top, width, height } = node.getComputedLayout()
 
   // Attach offset to the current node.

--- a/test/position.test.tsx
+++ b/test/position.test.tsx
@@ -8,7 +8,7 @@ describe('Position', () => {
   let fonts
   initFonts((f) => (fonts = f))
 
-  describe.todo('absolute', () => {
+  describe('absolute', () => {
     it('should support absolute position', async () => {
       const svg = await satori(
         <div

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "target": "ES2020",
     "lib": ["esnext", "dom"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- Fix Yoga version (newest version has broken `absolute` positioning support, see #90). This also makes sure that `yoga-wasm-web` and `yoga-layout-prebuilt` are referencing to the same upstream commit.
- Use WASM build of Satori/Yoga in the playground so the playground behaves the same as `@vercel/og`.
- Detect image type automatically because some servers don't return the `content-type` header.