### PR TITLE
Enable corepack with pnpm@7.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "postcss-value-parser": "^4.2.0",
     "yoga-layout-prebuilt": "^1.10.0"
   },
+  "packageManager": "pnpm@7.11.0",
   "engines": {
     "node": ">=16"
   }


### PR DESCRIPTION
This will pin the pnpm version so all contributors are developing using the same version, including the Vercel deployment.

https://vercel.com/changelog/corepack-experimental-is-now-available