### PR TITLE
Add project root wasm.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "license": "MPL-2.0",
   "files": [
-    "dist/**"
+    "dist/**",
+    "wasm.js"
   ],
   "exports": {
     "./package.json": "./package.json",

--- a/wasm.js
+++ b/wasm.js
@@ -1,0 +1,4 @@
+import Satori, { init } from './dist/esm/index.wasm.js'
+
+export default Satori
+export { init }


### PR DESCRIPTION
There seem to be some build tools that don't support package.json export fields. For these we add a wasm.js in the project root to work around it.