### PR TITLE
chore: fix typo

### DIFF
--- a/src/transform-origin.ts
+++ b/src/transform-origin.ts
@@ -74,7 +74,7 @@ function handleWord(
   }
 }
 
-export default function parseTranformOrigin(
+export default function parseTransformOrigin(
   value: string | number,
   baseFontSize: number
 ): ParsedTransformOrigin {


### PR DESCRIPTION
Fix typo `parseTranformOrigin` => `parseTransformOrigin`.