### PR TITLE
feat: support the lang="ja" attribute

### DIFF
--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -139,6 +139,7 @@ const loadDynamicAsset = withCache(
             data: font,
             weight: 400,
             style: 'normal',
+            lang: code === 'unknown' ? undefined : code
           }
         }
       }

--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -109,6 +109,7 @@ type LanguageCode = keyof typeof languageFontMap | 'emoji'
 
 const loadDynamicAsset = withCache(
   async (emojiType: keyof typeof apis, code: LanguageCode, text: string) => {
+    console.log('text', text)
     if (code === 'emoji') {
       // It's an emoji, load the image.
       return (

--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -109,7 +109,6 @@ type LanguageCode = keyof typeof languageFontMap | 'emoji'
 
 const loadDynamicAsset = withCache(
   async (emojiType: keyof typeof apis, code: LanguageCode, text: string) => {
-    console.log('text', text)
     if (code === 'emoji') {
       // It's an emoji, load the image.
       return (

--- a/src/font.ts
+++ b/src/font.ts
@@ -14,6 +14,8 @@ export interface FontOptions {
   style?: Style
 }
 
+const PREFIX = 'satori'
+
 function compareFont(
   weight,
   style,
@@ -157,7 +159,8 @@ export default class FontLoader {
       fontFamily: string | string[]
       fontWeight?: Weight | WeightName
       fontStyle?: Style
-    }
+    },
+    locale: string | undefined
   ) {
     if (!this.fonts.size) {
       throw new Error(
@@ -182,13 +185,25 @@ export default class FontLoader {
     const keys = Array.from(this.fonts.keys())
     for (const name of keys) {
       if (fontFamily.includes(name)) continue
-      fonts.push(
-        this.get({
-          name,
-          weight: fontWeight,
-          style: fontStyle,
-        })
-      )
+      if (locale) {
+        if (getLangFromFontName(name) === locale) {
+          fonts.push(
+            this.get({
+              name,
+              weight: fontWeight,
+              style: fontStyle
+            })
+          )
+        }
+      } else {
+        fonts.push(
+          this.get({
+            name,
+            weight: fontWeight,
+            style: fontStyle
+          })
+        )
+      }
     }
 
     const cachedFontResolver = new Map<number, opentype.Font | undefined>()
@@ -206,6 +221,7 @@ export default class FontLoader {
       if (font) {
         cachedFontResolver.set(code, font)
       }
+
       return font
     }
 
@@ -389,4 +405,12 @@ export default class FontLoader {
       unpatch()
     }
   }
+}
+
+function getLangFromFontName(name: string): string | undefined {
+  if (!name.startsWith(PREFIX)) {
+    return undefined
+  }
+
+  return name.split('_')[1] ?? undefined
 }

--- a/src/font.ts
+++ b/src/font.ts
@@ -109,6 +109,7 @@ export default class FontLoader {
   }
 
   public addFonts(fontOptions: FontOptions[]) {
+    console.log('fontOptions', fontOptions)
     for (const fontOption of fontOptions) {
       const data = fontOption.data
       const font = opentype.parse(

--- a/src/font.ts
+++ b/src/font.ts
@@ -109,7 +109,6 @@ export default class FontLoader {
   }
 
   public addFonts(fontOptions: FontOptions[]) {
-    console.log('fontOptions', fontOptions)
     for (const fontOption of fontOptions) {
       const data = fontOption.data
       const font = opentype.parse(
@@ -228,9 +227,6 @@ export default class FontLoader {
         )
       }
     }
-
-    console.log('this.fonts', this.fonts)
-    console.log('fonts', fonts)
 
     const cachedFontResolver = new Map<number, opentype.Font | undefined>()
     const resolveFont = (word: string, fallback = true) => {

--- a/src/font.ts
+++ b/src/font.ts
@@ -239,9 +239,9 @@ export default class FontLoader {
 
       const _fonts = [
         ...fonts,
+        ...additionalFonts,
         ...specifiedLangFonts,
         ...(fallback ? nonSpecifiedLangFonts : []),
-        ...additionalFonts
       ]
 
       const font = _fonts.find((_font, index) => {

--- a/src/language.ts
+++ b/src/language.ts
@@ -18,6 +18,7 @@ const emojiRegex = new RegExp(createEmojiRegex(), '')
 // to the Noto Sans font. A list of special cases we want to support can be
 // found here (sort by popularity):
 // - https://fonts.google.com/noto/fonts?sort=popularity&noto.query=sans
+// We can't tell if a hanzi(kanji) is Chinese or Japanese by regular expressions.
 const code = {
   emoji: emojiRegex,
   ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[，；：]|[\u3000]|[\uFF00-\uFFEF]/u,

--- a/src/language.ts
+++ b/src/language.ts
@@ -18,7 +18,9 @@ const emojiRegex = new RegExp(createEmojiRegex(), '')
 // to the Noto Sans font. A list of special cases we want to support can be
 // found here (sort by popularity):
 // - https://fonts.google.com/noto/fonts?sort=popularity&noto.query=sans
+//
 // We can't tell if a hanzi(kanji) is Chinese or Japanese by regular expressions.
+// - https://unicode.org/faq/han_cjk.html
 const code = {
   emoji: emojiRegex,
   ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[，；：]|[\u3000]|[\uFF00-\uFFEF]/u,

--- a/src/language.ts
+++ b/src/language.ts
@@ -20,7 +20,7 @@ const emojiRegex = new RegExp(createEmojiRegex(), '')
 // - https://fonts.google.com/noto/fonts?sort=popularity&noto.query=sans
 const code = {
   emoji: emojiRegex,
-  ja: /\p{scx=Hira}|\p{scx=Kana}|[\u3000]|[\uFF00-\uFFEF]/u,
+  ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[，；：]|[\u3000]|[\uFF00-\uFFEF]/u,
   ko: /\p{scx=Hangul}/u,
   zh: /\p{scx=Han}/u,
   th: /\p{scx=Thai}/u,
@@ -39,8 +39,18 @@ const code = {
 // Here we assume all characters from the passed in "segment" is in the same
 // written language. So if the string contains at least one matched character,
 // we determine it as the matched language.
-export function detectLanguageCode(segment: string): string {
-  for (const c in code) {
+export function detectLanguageCode(segment: string, locale?: string): string {
+  const order = Object.keys(code)
+  if (locale) {
+    const index = order.indexOf(locale)
+    if (index === -1) {
+      throw new Error('locale is invalid')
+    }
+    order.splice(index, 1)
+    order.unshift(locale)
+  }
+
+  for (const c of order) {
     if (code[c].test(segment)) {
       return c
     }

--- a/src/language.ts
+++ b/src/language.ts
@@ -25,7 +25,7 @@ const code = {
   emoji: emojiRegex,
   symbol: /\p{Symbol}/u,
   math: /\p{Math}/u,
-  ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[，；：]|[\u3000]|[\uFF00-\uFFEF]/u,
+  ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[\u3000]|[\uFF00-\uFFEF]/u,
   ko: /\p{scx=Hangul}/u,
   zh: /\p{scx=Han}/u,
   th: /\p{scx=Thai}/u,

--- a/src/language.ts
+++ b/src/language.ts
@@ -23,6 +23,8 @@ const emojiRegex = new RegExp(createEmojiRegex(), '')
 // - https://unicode.org/faq/han_cjk.html
 const code = {
   emoji: emojiRegex,
+  symbol: /\p{Symbol}/u,
+  math: /\p{Math}/u,
   ja: /\p{scx=Hira}|\p{scx=Kana}|\p{scx=Han}|[，；：]|[\u3000]|[\uFF00-\uFFEF]/u,
   ko: /\p{scx=Hangul}/u,
   zh: /\p{scx=Han}/u,
@@ -35,15 +37,16 @@ const code = {
   te: /\p{scx=Telugu}/u,
   devanagari: /\p{scx=Devanagari}/u,
   kannada: /\p{scx=Kannada}/u,
-  symbol: /\p{Symbol}/u,
-  math: /\p{Math}/u,
 } as const
 
 type CodeKey = keyof typeof code
-export type Locale = Exclude<CodeKey, 'emoji'>
+export type Locale = Exclude<CodeKey, 'emoji' | 'symbol' | 'math'>
 export type LangCode = CodeKey | 'unknown'
 
-const locales = Object.keys(code).splice(1) as Locale[]
+export const locales = Object.keys(code).splice(3) as Locale[]
+export function isValidLocale(x: any): x is Locale {
+  return locales.includes(x)
+}
 
 // Here we assume all characters from the passed in "segment" is in the same
 // written language. So if the string contains at least one matched character,
@@ -66,6 +69,7 @@ export function detectLanguageCode(segment: string, locale?: Locale): LangCode {
       return c
     }
   }
+
   return 'unknown'
 }
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -40,6 +40,8 @@ const code = {
 // Here we assume all characters from the passed in "segment" is in the same
 // written language. So if the string contains at least one matched character,
 // we determine it as the matched language.
+// Since some characters may belong to multiple languages simultaneously,
+// we adjust the order of the languages by locale.
 export function detectLanguageCode(segment: string, locale?: string): string {
   const order = Object.keys(code)
   if (locale) {

--- a/src/language.ts
+++ b/src/language.ts
@@ -37,7 +37,9 @@ const code = {
   math: /\p{Math}/u,
 } as const
 
-export type Locale = Exclude<keyof typeof code, 'emoji'>
+type CodeKey = keyof typeof code
+export type Locale = Exclude<CodeKey, 'emoji'>
+export type LangCode = CodeKey | 'unknown'
 
 const locales = Object.keys(code).splice(1) as Locale[]
 
@@ -46,8 +48,8 @@ const locales = Object.keys(code).splice(1) as Locale[]
 // we determine it as the matched language.
 // Since some characters may belong to multiple languages simultaneously,
 // we adjust the order of the languages by locale.
-export function detectLanguageCode(segment: string, locale?: Locale): string {
-  const order = Object.keys(code)
+export function detectLanguageCode(segment: string, locale?: Locale): LangCode {
+  const order = Object.keys(code) as CodeKey[]
   if (locale) {
     const index = order.indexOf(locale)
     if (index === -1) {

--- a/src/language.ts
+++ b/src/language.ts
@@ -35,14 +35,18 @@ const code = {
   kannada: /\p{scx=Kannada}/u,
   symbol: /\p{Symbol}/u,
   math: /\p{Math}/u,
-}
+} as const
+
+export type Locale = Exclude<keyof typeof code, 'emoji'>
+
+const locales = Object.keys(code).splice(1) as Locale[]
 
 // Here we assume all characters from the passed in "segment" is in the same
 // written language. So if the string contains at least one matched character,
 // we determine it as the matched language.
 // Since some characters may belong to multiple languages simultaneously,
 // we adjust the order of the languages by locale.
-export function detectLanguageCode(segment: string, locale?: string): string {
+export function detectLanguageCode(segment: string, locale?: Locale): string {
   const order = Object.keys(code)
   if (locale) {
     const index = order.indexOf(locale)
@@ -59,4 +63,8 @@ export function detectLanguageCode(segment: string, locale?: string): string {
     }
   }
   return 'unknown'
+}
+
+export function normalizeLocale(lang?: string): Locale | undefined {
+  return locales.find(_locale => lang && lang.startsWith(_locale))
 }

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -127,19 +127,15 @@ export default async function satori(
 
   const segmentsMissingFont = (await handler.next()).value as {word: string, locale?: Locale}[]
 
-  console.log('segmentsMissingFont', segmentsMissingFont)
-
   if (options.loadAdditionalAsset) {
     if (segmentsMissingFont.length) {
       const languageCodes = convertToLanguageCodes(segmentsMissingFont)
       const fonts: FontOptions[] = []
       const images: Record<string, string> = {}
-      console.log('languageCodes', languageCodes)
 
       await Promise.all(
         Object.entries(languageCodes).flatMap(([code, segments]) =>
           segments.map((_segment) => {
-            console.log('code, _segment', code, _segment)
             const key = `${code}_${_segment}`
             if (processedWordsMissingFonts.has(key)) {
               return null
@@ -185,8 +181,6 @@ function convertToLanguageCodes(segmentsMissingFont: {word: string, locale?: Loc
     wordsByCode[code] += word
   }
 
-  console.log('wordsByCode', wordsByCode)
-
   Object.keys(wordsByCode).forEach((code: LangCode) => {
     languageCodes[code] = languageCodes[code] || []
     if (code === 'emoji') {
@@ -196,8 +190,6 @@ function convertToLanguageCodes(segmentsMissingFont: {word: string, locale?: Loc
       languageCodes[code][0] += unique(segment(wordsByCode[code], 'grapheme', code === 'unknown' ? undefined : code)).join('')
     }
   })
-
-  console.log('languageCodes', languageCodes)
 
   return languageCodes
 }

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -122,15 +122,15 @@ export default async function satori(
 
       const languageCodes: Record<string, string[]> = {}
       segmentsMissingFont.forEach(({words, locale }) => {
-          words.forEach(seg => {
-            const code = locale ? locale : detectLanguageCode(seg)
-            languageCodes[code] = languageCodes[code] || []
-            if (code === 'emoji') {
-              languageCodes[code].push(seg)
-            } else {
-              languageCodes[code][0] = (languageCodes[code][0] || '') + seg
-            }
-          })
+        words.forEach(seg => {
+          const code = detectLanguageCode(seg, locale)
+          languageCodes[code] = languageCodes[code] || []
+          if (code === 'emoji') {
+            languageCodes[code].push(seg)
+          } else {
+            languageCodes[code][0] = (languageCodes[code][0] || '') + seg
+          }
+        })
       })
 
       const fonts: FontOptions[] = []

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -5,7 +5,7 @@ import layout from './layout'
 import FontLoader, { FontOptions } from './font'
 import svg from './builder/svg'
 import { segment } from './utils'
-import { detectLanguageCode } from './language'
+import {detectLanguageCode, Locale} from './language'
 import getTw from './handler/tailwind'
 
 // We don't need to initialize the opentype instances every time.
@@ -112,7 +112,7 @@ export default async function satori(
     },
   })
 
-  const _segmentsMissingFont = (await handler.next()).value as {word: string, locale?: string}[]
+  const _segmentsMissingFont = (await handler.next()).value as {word: string, locale?: Locale}[]
 
   let segmentsMissingFont: { words: string[], locale: string }[] = []
 
@@ -123,7 +123,7 @@ export default async function satori(
       const languageCodes: Record<string, string[]> = {}
       segmentsMissingFont.forEach(({words, locale }) => {
         words.forEach(seg => {
-          const code = detectLanguageCode(seg, locale)
+          const code = detectLanguageCode(seg, locale as Locale)
           languageCodes[code] = languageCodes[code] || []
           if (code === 'emoji') {
             languageCodes[code].push(seg)
@@ -169,7 +169,7 @@ export default async function satori(
   return svg({ width: computedWidth, height: computedHeight, content })
 }
 
-function helper(_segmentsMissingFont): { words: string[], locale: string }[] {
+function helper(_segmentsMissingFont: {word: string, locale?: Locale}[]): { words: string[], locale: Locale }[] {
   const graphemeArray = []
   let lastLocale = undefined
   let tempWords = ''

--- a/src/text.ts
+++ b/src/text.ts
@@ -9,11 +9,12 @@ import { v, segment, wordSeparators, buildXMLString } from './utils'
 import text, { container } from './builder/text'
 import { dropShadow } from './builder/shadow'
 import decoration from './builder/text-decoration'
+import {Locale} from "./language";
 
 export default async function* buildTextNodes(
   content: string,
   context: LayoutContext
-): AsyncGenerator<{word: string, locale: string}[], string, [any, any]> {
+): AsyncGenerator<{word: string, locale?: Locale}[], string, [any, any]> {
   const Yoga = getYoga()
 
   const {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,9 +148,6 @@ export function v(
   return value
 }
 
-// @TODO: Support "lang" attribute to modify the locale
-const locale = undefined
-
 let wordSegmenter
 let graphemeSegmenter
 
@@ -163,7 +160,8 @@ export const wordSeparators = [
 
 export function segment(
   content: string,
-  granularity: 'word' | 'grapheme'
+  granularity: 'word' | 'grapheme',
+  locale?: string
 ): string[] {
   if (!wordSegmenter || !graphemeSegmenter) {
     if (!(typeof Intl !== 'undefined' && 'Segmenter' in Intl)) {

--- a/test/language.test.tsx
+++ b/test/language.test.tsx
@@ -12,20 +12,36 @@ describe('detectLanguageCode', () => {
     expect(detectLanguageCode('👋 vs 🌊')).toBe('emoji')
   })
 
-  it('should detect japanese', async () => {
+  it('should detect japanese(hiragana)', async () => {
     expect(detectLanguageCode('こんにちは')).toBe('ja')
+  })
+
+  it('should detect japanese(katakana)', async () => {
+    expect(detectLanguageCode('ハナミズキ')).toBe('ja')
+  })
+
+  it('should detect japanese（kanji)', async () => {
+    expect(detectLanguageCode('桜')).toBe('ja')
+  })
+
+  it('should detect japanese(hiragana) when locale is zh', async () => {
+    expect(detectLanguageCode('こんにちは')).toBe('ja')
+  })
+
+  it('should detect japanese(katakana) when locale is zh', async () => {
+    expect(detectLanguageCode('ハナミズキ')).toBe('ja')
+  })
+
+  it('should detect simplified chinese when locale is zh', async () => {
+    expect(detectLanguageCode('我知道怎么说中文', 'zh')).toBe('zh')
+  })
+
+  it('should detect traditional chinese when locale is zh', async () => {
+    expect(detectLanguageCode('我知道怎麼說中文', 'zh')).toBe('zh')
   })
 
   it('should detect korean', async () => {
     expect(detectLanguageCode('안녕하세요')).toBe('ko')
-  })
-
-  it('should detect simplified chinese', async () => {
-    expect(detectLanguageCode('我知道怎么说中文')).toBe('zh')
-  })
-
-  it('should detect traditional chinese', async () => {
-    expect(detectLanguageCode('我知道怎麼說中文')).toBe('zh')
   })
 
   it('should detect thai', async () => {


### PR DESCRIPTION
### Description
Support the `lang="ja"` attribute.

1. For those words with the same Unicode Code Point but different glyphs (in different languages), different glyphs need to be displayed according to the lang attribute. Such as `刃直海角骨入`.
2. Chinese characters (e.g. `樱`) can also be displayed correctly (through safe fallback) under the label with lang="ja" set.
3. Japenese kanji (e.g. `桜`) can also be displayed correctly (through safe fallback) under the label with lang="zh" set.

Because we can't distinguish Chinese hanzi and Japanese kanji by regex, this PR uses some tricky codes when implementing the above feature. So I'm wondering if I need to do this. Are there two other straightforward implementations below that might look better?
1. Give up displaying hanzi when the user sets lang="ja".
2. We download all possible languages ​​when we need to download hanzi(kanji).

What do you think? 🤔

### Additional
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/22126563/199142248-05487041-6086-493c-a472-34af5aa75c64.png">

Closes: #170 