### PR TITLE
Support Noto math and symbol fonts

### DIFF
--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -38,6 +38,8 @@ const languageFontMap = {
   te: 'Noto+Sans+Telugu',
   ml: 'Noto+Sans+Malayalam',
   devanagari: 'Noto+Sans+Devanagari',
+  symbol: ['Noto+Sans+Symbols', 'Noto+Sans+Symbols+2'],
+  math: 'Noto+Sans+Math',
   unknown: 'Noto+Sans',
 }
 
@@ -113,23 +115,28 @@ const loadDynamicAsset = withCache(
     }
 
     // Try to load from Google Fonts.
-    if (!languageFontMap[code]) code = 'unknown'
+    let names = languageFontMap[code]
+    if (!names) code = 'unknown'
 
     try {
-      const font = await (
-        await fetch(
-          `/api/font?font=${encodeURIComponent(
-            languageFontMap[code]
-          )}&text=${encodeURIComponent(text)}`
-        )
-      ).arrayBuffer()
+      if (typeof names === 'string') {
+        names = [names]
+      }
 
-      if (font) {
-        return {
-          name: `satori_${code}_fallback_${text}`,
-          data: font,
-          weight: 400,
-          style: 'normal',
+      for (const name of names) {
+        const res = await fetch(
+          `/api/font?font=${encodeURIComponent(name)}&text=${encodeURIComponent(
+            text
+          )}`
+        )
+        if (res.status === 200) {
+          const font = await res.arrayBuffer()
+          return {
+            name: `satori_${code}_fallback_${text}`,
+            data: font,
+            weight: 400,
+            style: 'normal',
+          }
         }
       }
     } catch (e) {

--- a/src/language.ts
+++ b/src/language.ts
@@ -31,6 +31,8 @@ const code = {
   he: /\p{scx=Hebrew}/u,
   te: /\p{scx=Telugu}/u,
   devanagari: /\p{scx=Devanagari}/u,
+  symbol: /\p{Symbol}/u,
+  math: /\p{Math}/u,
 }
 
 // Here we assume all characters from the passed in "segment" is in the same


### PR DESCRIPTION
Makes sure it can match the Symbol and Math blocks and use corresponding Noto fonts to render them. Also this PR fixes the bug where the font API fails to load.

[Playground](https://satori-playground-git-shu-c1a3.vercel.sh/?share=XZK_TsMwEMZf5WSEupTW0DQFq3SgIMHARCWWLGnjpC5OHCVO_6ob4gEYEAMVOwsDYuJt-gR9BM4JqUoHK-ffl7vPd_aCDJTHCSNtT4ydCCDVM8nPFwsTAwy5CIaaQeWY0sNKtYAT4enhHvNEGkt3htSXfFpSE1-KhA-0UBFqAyWzMCpVV4ogutE8TI3EI82TUhplqRb-rKsQRsb_v9x3Bw9BorLI6yqpEtQPfN_fumLWnZhzBo2THXT_14tNaU6XSyfqmKCdjoOdzs4d0mo6pCBjwScXaoqMAoVWE-yt5AspkR9QSktUDg9CNwmE6djkxNNKbgaQ26Fh7OoheJh822jVmme1k6Zs2LUzrG5d12yr2BzZ1twhnXbd_F0ctI4nLSK8rX23nooZWBStOuu3D9i8r75g_fQM69efKmxWLxg9fuJa4fpu17ECliq_pEpUbG4pJWxB8jkQdoqTIsUTIMwyG4_3s4Aw35UprxIeqpHozWLzfvQk32EdM-ursM89wnSS8eXyFw):

![image](https://user-images.githubusercontent.com/3676859/200165316-0220cb1e-6aac-4460-9cd0-d0fa2576f8a6.png)

Closes #271, closes #272.