### PR TITLE
Add exports of `Font`, `FontWeight`, `FontStyle` types

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -3,9 +3,9 @@
  */
 import opentype from '@shuding/opentype.js'
 
-type Weight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
+export type Weight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900
 type WeightName = 'normal' | 'bold'
-type Style = 'normal' | 'italic'
+export type Style = 'normal' | 'italic'
 
 export interface FontOptions {
   data: Buffer | ArrayBuffer

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
+export type {
+  FontOptions as Font,
+  Weight as FontWeight,
+  Style as FontStyle,
+} from './font'
 export * from './satori'
 export { default } from './satori'


### PR DESCRIPTION
This adds some exports of subtypes in options. It should simplify code of users that try to model the font options. For example, I currently have:

```js
/**
 * @typedef {import('satori').SatoriOptions['fonts'][number]} Font
 * @typedef {Exclude<Font['weight'], undefined>} FontWeight
 * @typedef {Exclude<Font['style'], undefined>} FontStyle
 */
```

These new exports help clean that code up