### PR TITLE
fix: support for kannada

### DIFF
--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -38,6 +38,7 @@ const languageFontMap = {
   te: 'Noto+Sans+Telugu',
   ml: 'Noto+Sans+Malayalam',
   devanagari: 'Noto+Sans+Devanagari',
+  kannada: 'Noto+Sans+Kannada',
   symbol: ['Noto+Sans+Symbols', 'Noto+Sans+Symbols+2'],
   math: 'Noto+Sans+Math',
   unknown: 'Noto+Sans',

--- a/src/language.ts
+++ b/src/language.ts
@@ -31,6 +31,7 @@ const code = {
   he: /\p{scx=Hebrew}/u,
   te: /\p{scx=Telugu}/u,
   devanagari: /\p{scx=Devanagari}/u,
+  kannada: /\p{scx=Kannada}/u,
   symbol: /\p{Symbol}/u,
   math: /\p{Math}/u,
 }


### PR DESCRIPTION
Works locally to fix the rendering image. ~Still working on getting it deployed to Vercel for a live example.~ [Live example](https://satori-playground-ianonavy.vercel.app/?share=XZA9TsQwEIWvYg1CC9JKhB8hZC00CwU1SDRpkniceHHsKHZYQpSKjoIL0MAV6LkLEkJcg3GWINjGmvmePeP3OsisQOAwE-omNow532o87rpQM1agygvP2WQ3ijYn0xVcKuGLNSaUq3TSEpUab0ca6lNVY-aVNaRlVjelGdVEq9yceyxdkNB4rEdp0TivZDu3BE3Y_19Ok-w6r21jxNxqW5O-IaX83UqvLtQdcra_9wdd_Xg5jKKB9n1sTkKx9XH_-P76_PX0QOc2NZ9vLyw2sx2KhC7AFGwVDDjgHQzmgR_REFilA_wgNALTJgcuE-1wCljahbpsqxCtXw4dzQnfOCtTFMB93WDffwM).

<img width="1579" alt="Screenshot of satori playground showing the angry emoticon working" src="https://user-images.githubusercontent.com/790279/202571991-9673f11a-9ac8-4ad7-bfe8-1eaf6a6169c3.png">

Closes #313