### PR TITLE
Support full width characters and symbols for support for common Japanese text

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -20,7 +20,7 @@ const emojiRegex = new RegExp(createEmojiRegex(), '')
 // - https://fonts.google.com/noto/fonts?sort=popularity&noto.query=sans
 const code = {
   emoji: emojiRegex,
-  ja: /\p{scx=Hira}|\p{scx=Kana}|[，；：]/u,
+  ja: /\p{scx=Hira}|\p{scx=Kana}|[\u3000]|[\uFF00-\uFFEF]/u,
   ko: /\p{scx=Hangul}/u,
   zh: /\p{scx=Han}/u,
   th: /\p{scx=Thai}/u,


### PR DESCRIPTION
This PR modifies the language test to add the unicode blocks for [Halfwidth_And_Fullwidth_Forms](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=[:Block=Halfwidth_And_Fullwidth_Forms:]) as well as the fullwidth space character `　`.

Fixes #343 (my issue)

### **Impact other East Asian languages**
AFAIK Chinese and Korean language also uses full-width characters, these should be identical across all the Noto CJK fonts, so there should be no issue with their use in either language. 

I admit I'm not familiar with `Hangul` or `Han` script sets, but as far as I can see, the language matcher matches segments based on `word` – in the case of CJK languages I'd assume this is character-by-character. I can see that the same approach was taken by setting the specific order of language detection (ja -> ko -> zh) so that the shared chinese script is the fallback for Japanese kanji.

### **Playground before and after**
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1182105/209899640-eaf3cf44-3f26-4161-8619-128dc36f07e5.png">

This commit:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1182105/209899662-f9340eb3-2db8-4860-aa44-c9bb9a1683f1.png">
