### PR TITLE
Change language code to locale code, add readme and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,20 @@ await satori(
 
 The image will be resized to the current font-size (both width and height) as a square.
 
+#### Locales
+
+Satori supports rendering text in different locales. You can specify the supported locales via the `lang` attribute:
+
+```jsx
+await satori(
+  <div lang="ja-JP">骨</div>
+)
+```
+
+Same characters can be rendered differently in different locales, you can specify the locale when necessary to force it to render with a specific font and locale. Check out [this example](https://og-playground.vercel.app/?share=nVLdSsMwFH6VcEC86VgdXoyweTMVpyiCA296kzWnbWaalCZ160rfwAcRH8Bn0rcwWVdQEYTdnJzz_ZyEnNNArDkChQkXz5EixNha4rRpfE4IF6aQrKbkOJG4OQ461OfnosTYCq0cF2tZ5apnMxRpZh18EoZHPbgW3Ga_sIJxLlS6Q4sNGbnQU0yKVM0t5sa3R2Wx7KlVZaxI6pl2oPLX_KQTh1-yXEj_6LlnAhLBLXOJYJLMY61MBN_VD2KLlIzGe2jJ4qe01JXiMy116bqsM2Gxc7Stj2edcmIKpohkKp1GsGKD6_sI9hQhn2-vHy_ve-HQK_9ybbPB7O4Q1-LxENfVzX-uydDtgTshAF348RqgDeymB3QchgF04wV66guOyyoFmjBpMADM9Uos6sLvk13vKtfH__FFvkQO1JYVtu0X) to learn more. 
+
+Supported locales are exported as the `Locale` enum type.
+
 #### Dynamically Load Emojis and Fonts
 
 Satori supports dynamically loading emoji images (grapheme pictures) and fonts. The `loadAdditionalAsset` function will be called when a text segment is rendered but missing the image or font:

--- a/playground/cards/playground-data.ts
+++ b/playground/cards/playground-data.ts
@@ -266,48 +266,64 @@ const playgroundTabs: Tabs = {
 
 // You can also return a function component in the playground.
 () => {
-function Label({ children }) {
-  return <label style={{
-    fontSize: 15,
-    fontWeight: 600,
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-    margin: '20px 0 10px',
-    color: 'gray',
-  }}>
-    {children}
-  </label>
-}
+  function Label({ children }) {
+    return <label style={{
+      fontSize: 15,
+      fontWeight: 600,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+      margin: '25px 0 10px',
+      color: 'gray',
+    }}>
+      {children}
+    </label>
+  }
 
-return (
-  <div
-    style={{
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      width: '100%',
-      padding: '10px 20px',
-      justifyContent: 'center',
-      fontFamily: 'Inter, "Material Icons"',
-      fontSize: 28,
-      backgroundColor: 'white',
-    }}
-    >
-    <Label>Language & Font subsets</Label>
-    <div>
-      Hello! 你好! 안녕! こんにちは! Χαίρετε! Hallå!
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        width: '100%',
+        padding: '10px 20px',
+        justifyContent: 'center',
+        fontFamily: 'Inter, "Material Icons"',
+        fontSize: 28,
+        backgroundColor: 'white',
+      }}
+      >
+      <Label>Language & Font subsets</Label>
+      <div>
+        Hello! 你好! 안녕! こんにちは! Χαίρετε! Hallå!
+      </div>
+      <Label>Emoji</Label>
+      <div>
+        👋 😄 🎉 🎄 🦋
+      </div>
+      <Label>Icon font</Label>
+      <div>
+          &#xe766; &#xeb9b; &#xf089;
+      </div>
+      <Label>Lang attribute</Label>
+      <div style={{ display: 'flex' }}>
+        <span lang="ja-JP">
+          骨茶
+        </span>/
+        <span lang="zh-CN">
+          骨茶
+        </span>/
+        <span lang="zh-TW">
+          骨茶
+        </span>/
+        <span lang="zh-HK">
+          骨茶
+        </span>
+      </div>
     </div>
-    <Label>Emoji</Label>
-    <div>
-      👋 😄 🎉 🎄 🦋
-    </div>
-    <Label>Icon font</Label>
-    <div>
-        &#xe766; &#xeb9b; &#xf089;
-    </div>
-  </div>
-)
-}`,
+  )
+}  
+`,
 }
 
 export default playgroundTabs

--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -29,16 +29,18 @@ const editedCards: Tabs = { ...playgroundTabs }
 // than built-in.
 // @TODO: Cover most languages with Noto Sans.
 const languageFontMap = {
-  zh: 'Noto+Sans+SC',
-  ja: 'Noto+Sans+JP',
-  ko: 'Noto+Sans+KR',
-  th: 'Noto+Sans+Thai',
-  he: 'Noto+Sans+Hebrew',
-  ar: 'Noto+Sans+Arabic',
-  bn: 'Noto+Sans+Bengali',
-  ta: 'Noto+Sans+Tamil',
-  te: 'Noto+Sans+Telugu',
-  ml: 'Noto+Sans+Malayalam',
+  'ja-JP': 'Noto+Sans+JP',
+  'ko-KR': 'Noto+Sans+KR',
+  'zh-CN': 'Noto+Sans+SC',
+  'zh-TW': 'Noto+Sans+TC',
+  'zh-HK': 'Noto+Sans+HK',
+  'th-TH': 'Noto+Sans+Thai',
+  'bn-IN': 'Noto+Sans+Bengali',
+  'ar-AR': 'Noto+Sans+Arabic',
+  'ta-IN': 'Noto+Sans+Tamil',
+  'ml-IN': 'Noto+Sans+Malayalam',
+  'he-IL': 'Noto+Sans+Hebrew',
+  'te-IN': 'Noto+Sans+Telugu',
   devanagari: 'Noto+Sans+Devanagari',
   kannada: 'Noto+Sans+Kannada',
   symbol: ['Noto+Sans+Symbols', 'Noto+Sans+Symbols+2'],
@@ -139,7 +141,7 @@ const loadDynamicAsset = withCache(
             data: font,
             weight: 400,
             style: 'normal',
-            lang: code === 'unknown' ? undefined : code
+            lang: code === 'unknown' ? undefined : code,
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,7 @@ export type {
   Weight as FontWeight,
   Style as FontStyle,
 } from './font'
+export type { Locale } from './language'
+
 export * from './satori'
 export { default } from './satori'

--- a/test/language.test.tsx
+++ b/test/language.test.tsx
@@ -13,63 +13,67 @@ describe('detectLanguageCode', () => {
   })
 
   it('should detect japanese(hiragana)', async () => {
-    expect(detectLanguageCode('こんにちは')).toBe('ja')
+    expect(detectLanguageCode('こんにちは')).toBe('ja-JP')
   })
 
   it('should detect japanese(katakana)', async () => {
-    expect(detectLanguageCode('ハナミズキ')).toBe('ja')
+    expect(detectLanguageCode('ハナミズキ')).toBe('ja-JP')
   })
 
   it('should detect japanese（kanji)', async () => {
-    expect(detectLanguageCode('桜')).toBe('ja')
+    expect(detectLanguageCode('桜')).toBe('ja-JP')
   })
 
   it('should detect japanese(hiragana) when locale is zh', async () => {
-    expect(detectLanguageCode('こんにちは')).toBe('ja')
+    expect(detectLanguageCode('こんにちは')).toBe('ja-JP')
   })
 
   it('should detect japanese(katakana) when locale is zh', async () => {
-    expect(detectLanguageCode('ハナミズキ')).toBe('ja')
+    expect(detectLanguageCode('ハナミズキ')).toBe('ja-JP')
   })
 
-  it('should detect simplified chinese when locale is zh', async () => {
-    expect(detectLanguageCode('我知道怎么说中文', 'zh')).toBe('zh')
+  it('should detect simplified chinese when locale is zh-cn', async () => {
+    expect(detectLanguageCode('我知道怎么说中文', 'zh-CN')).toBe('zh-CN')
   })
 
-  it('should detect traditional chinese when locale is zh', async () => {
-    expect(detectLanguageCode('我知道怎麼說中文', 'zh')).toBe('zh')
+  it('should detect traditional chinese when locale is zh-cn', async () => {
+    expect(detectLanguageCode('我知道怎麼說中文', 'zh-CN')).toBe('zh-CN')
+  })
+
+  it('should detect traditional chinese when locale is zh-tw', async () => {
+    expect(detectLanguageCode('我知道怎麼說中文', 'zh-TW')).toBe('zh-TW')
   })
 
   it('should detect korean', async () => {
-    expect(detectLanguageCode('안녕하세요')).toBe('ko')
+    expect(detectLanguageCode('안녕하세요')).toBe('ko-KR')
   })
 
   it('should detect thai', async () => {
-    expect(detectLanguageCode('สวัสดี')).toBe('th')
+    expect(detectLanguageCode('สวัสดี')).toBe('th-TH')
   })
 
   it('should detect arabic', async () => {
-    expect(detectLanguageCode('مرحبا')).toBe('ar')
+    expect(detectLanguageCode('مرحبا')).toBe('ar-AR')
   })
 
   it('should detect tamil', async () => {
-    expect(detectLanguageCode('வணக்கம்')).toBe('ta')
+    expect(detectLanguageCode('வணக்கம்')).toBe('ta-IN')
   })
 
   it('should detect bengali', async () => {
-    expect(detectLanguageCode('হ্যালো')).toBe('bn')
+    expect(detectLanguageCode('হ্যালো')).toBe('bn-IN')
   })
 
   it('should detect malayalam', async () => {
-    expect(detectLanguageCode('ഹായ്')).toBe('ml')
+    expect(detectLanguageCode('ഹായ്')).toBe('ml-IN')
   })
 
   it('should detect hebrew', async () => {
-    expect(detectLanguageCode('שלום')).toBe('he')
+    expect(detectLanguageCode('שלום')).toBe('he-IL')
   })
 
   it('should detect telegu', async () => {
-    expect(detectLanguageCode('హలో')).toBe('te')
+    expect(detectLanguageCode('హలో')).toBe('te-IN')
   })
 
   it('should detect devanagari', async () => {


### PR DESCRIPTION
It's more accurate to use locale codes (lang-region) instead of language codes, as the fonts and glyphs are determined by the actual locale.