### PR TITLE
fix: fix type exports for `wasm` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "module": "./dist/index.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "wasm": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "type": "module",
   "license": "MPL-2.0",
   "files": [
@@ -14,10 +21,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./wasm": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.wasm.js",
       "require": "./dist/index.wasm.cjs"
     }


### PR DESCRIPTION
i tested this change with https://arethetypeswrong.github.io/

before:
<img width="493" alt="Снимок экрана 2023-03-09 в 12 50 49" src="https://user-images.githubusercontent.com/6726016/223985183-7a151258-bf91-46cc-852d-27f656c6b0d8.png">

after: 
<img width="689" alt="Снимок экрана 2023-03-09 в 12 50 26" src="https://user-images.githubusercontent.com/6726016/223985235-4cd49a12-c3a5-4f97-b2b7-f598333c347e.png">


There is still space for improvement for example generating proper types for CJS entry 

