### PR TITLE
chore: Should fallback to helloworld tab to show code for old share link

### DIFF
--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -919,7 +919,7 @@ function ResetCode({ activeCard }: { activeCard: string }) {
           const decoded = JSON.parse(decompressedData)
           card = decoded.code
           overrideOptions = decoded.options
-          tab = decoded.tab
+          tab = decoded.tab || 'helloworld'
         } catch (e) {
           card = decompressedData
         }


### PR DESCRIPTION
old share link like https://og-playground.vercel.app/?share=VY5BDoIwEEWv0kxi0KTGmuimUXfewCUbYIZShRlSioYQ7i6oG5fvLf77IxSCBBZO6J-qi0NN53FMWamXx1hZleyNWSV6MRV5V8U_lWfFwwXpGWdde6YsbF3I0BPH9fZwRHJaFcE3nbA6mpVWTmokDoILbpKUp2l3AQ3SRi_cgR3hUwZ7MEbDt_kDpLx3YMus7kgDNXL3t6Fd3rNEmUdK4XhtckKwMfQ0TW8 cannot show code correctly. here we set the tab to helloworld by default