### PR TITLE
fix: Throw error if fetching relative url from the server

### DIFF
--- a/src/handler/image.ts
+++ b/src/handler/image.ts
@@ -159,6 +159,14 @@ export async function resolveImageData(
     src = src.slice(1, -1)
   }
 
+  // Throw error if the image source is not an absolute URL in server environment
+  // Should be after slicing quotes to avoid throwing error too early
+  if (typeof window === 'undefined') {
+    if (!src.startsWith('http') && !src.startsWith('data:')) {
+      throw new Error(`Image source must be an absolute URL: ${src}`)
+    }
+  }
+
   if (src.startsWith('data:')) {
     let decodedURI: { imageType; encodingType; dataString }
 

--- a/test/image.test.tsx
+++ b/test/image.test.tsx
@@ -103,6 +103,17 @@ describe('Image', () => {
     expect(requests).toEqual(['https://via.placeholder.com/150'])
   })
 
+  it('should throw error when relative path is used', async () => {
+    await expect(
+      satori(
+        <div>
+          <img width='100%' height='100%' src='/image.png' />
+        </div>,
+        { width: 100, height: 100, fonts }
+      )
+    ).rejects.toThrowError('Image source must be an absolute URL: /image.png')
+  })
+
   it('should deduplicate image data requests', async () => {
     const svg = await satori(
       <div


### PR DESCRIPTION
Addresses #203 by placing a check on absolute url patterns by checking if the URL begins with 'http' or 'data:' format. Also added in a test to check for relative urls.  