### PR TITLE
fix: Remove `emoji-regex` from externals

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   minify: process.env.NODE_ENV !== 'development',
   format: ['esm', 'cjs'],
-  noExternal: ['twrnc'],
+  noExternal: ['twrnc', 'emoji-regex'],
   esbuildOptions(options) {
     if (process.env.WASM) {
       options.outExtension = {


### PR DESCRIPTION
Should fix #451 but we need to test after the release.