### PR TITLE
chore: rename node-version to node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18 ]
+        node: [ 18 ]
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR renames the property name.

The `integrity` job uses `${{ matrix.node }}` but `matrix` property defines `node-version: [ 18 ]` so it doesn't work correctly. It looks the job uses Node.js 18 since it is the default version.

https://github.com/vercel/satori/blob/main/.github/workflows/ci.yml
```yml
  integrity:
    # prevents this action from running on forks
    if: github.repository_owner == 'vercel'
    runs-on: ubuntu-latest
    strategy:
      matrix:
        node-version: [ 18 ]
    steps:
    - name: Checkout
      uses: actions/checkout@v3
    - name: Use pnpm
      run: corepack enable pnpm && pnpm --version
    - name: Use Node.js ${{ matrix.node }}
      uses: actions/setup-node@v3
      with:
        node-version: ${{ matrix.node }}
        cache: 'pnpm'
    - run: pnpm install
    - run: pnpm ci-check
```

`setup-node`'s example uses `node` instead of `node-version` so I renamed it from `node-version` to `node`.
https://github.com/actions/setup-node#matrix-testing

