### PR TITLE
chore(playground): reset default tab-size to 8

### DIFF
--- a/playground/pages/index.tsx
+++ b/playground/pages/index.tsx
@@ -687,7 +687,7 @@ const LiveSatori = withLive(function ({
                       <>
                         <style
                           dangerouslySetInnerHTML={{
-                            __html: `@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Material+Icons');body{display:flex;height:100%;margin:0;font-family:Inter,sans-serif;overflow:hidden}body>div,body>div *{box-sizing:border-box;display:flex}`,
+                            __html: `@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Material+Icons');body{display:flex;height:100%;margin:0;tab-size:8;font-family:Inter,sans-serif;overflow:hidden}body>div,body>div *{box-sizing:border-box;display:flex}`,
                           }}
                         />
                         {live?.element ? <live.element /> : null}


### PR DESCRIPTION
### Description
Reset default tab-size to 8 to ensure 'satori' has the same effect as 'html' without setting tab-size.

before:
<img width="1438" alt="image" src="https://github.com/vercel/satori/assets/22126563/02547a14-acff-4702-a52a-2e01e43be041">

after:
<img width="1439" alt="image" src="https://github.com/vercel/satori/assets/22126563/bab20234-f493-4323-9ad7-a074ff970c94">

