### PR TITLE
refactor: Remove redundant check

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --quiet --cache",
     "lint:fix": "pnpm lint --fix",
     "prettier-check": "prettier --check .",
-    "prettier-fix": "prettier --write . --cache",
+    "prettier-fix": "prettier --write --list-different . --cache",
     "ci-check": "concurrently \"pnpm prettier-check\" \"pnpm test-type\" \"pnpm lint\""
   },
   "lint-staged": {

--- a/src/language.ts
+++ b/src/language.ts
@@ -86,9 +86,6 @@ export function detectLanguageCode(
 
 export function normalizeLocale(locale?: string): Locale | undefined {
   if (locale) {
-    return locales.find(
-      (l) =>
-        l.toLowerCase().startsWith(locale.toLowerCase())
-    )
+    return locales.find((l) => l.toLowerCase().startsWith(locale.toLowerCase()))
   }
 }

--- a/src/language.ts
+++ b/src/language.ts
@@ -88,7 +88,6 @@ export function normalizeLocale(locale?: string): Locale | undefined {
   if (locale) {
     return locales.find(
       (l) =>
-        l.toLowerCase() === locale.toLowerCase() ||
         l.toLowerCase().startsWith(locale.toLowerCase())
     )
   }


### PR DESCRIPTION
`'foo'.startsWith('foo') // true`