### PR TITLE
fix: clear inflight request map for image resolution

### DIFF
--- a/src/handler/image.ts
+++ b/src/handler/image.ts
@@ -62,7 +62,7 @@ import { createLRU, parseViewBox } from '../utils.js'
 
 type ResolvedImageData = [string, number?, number?] | readonly []
 export const cache = createLRU<ResolvedImageData>(100)
-const inflightRequests = new Map<string, Promise<ResolvedImageData>>()
+export const inflightRequests = new Map<string, Promise<ResolvedImageData>>()
 
 const ALLOWED_IMAGE_TYPES = [PNG, APNG, JPEG, GIF, SVG]
 

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -10,7 +10,7 @@ import { segment } from './utils.js'
 import { detectLanguageCode, LangCode, Locale } from './language.js'
 import getTw from './handler/tailwind.js'
 import { preProcessNode } from './handler/preprocess.js'
-import { cache } from './handler/image.js'
+import { cache, inflightRequests } from './handler/image.js'
 
 // We don't need to initialize the opentype instances every time.
 const fontCache = new WeakMap()
@@ -90,6 +90,7 @@ export default async function satori(
   const processedWordsMissingFonts = new Set()
 
   cache.clear()
+  inflightRequests.clear()
   await preProcessNode(element)
 
   const handler = layout(element, {


### PR DESCRIPTION
Closes #650

## Current behavior

Try changing the background color in the `main` [playground link](https://og-playground.vercel.app/?share=7VVdb9owFP0rlvfSScH5BEIEnVZUqZ3UrZ2qTZN4CYmTmDpxZhsCQ_z33XxBqvVp2uOMUHyvj-899_o4OeJIxBQHeB6z3apASOkDp4vjsZ4jFDNV8vAQoBVOON2vsNH6N1ulWXJYikLTQtfLETypPANCztLiXtNcvVpE7WrFYp0FyLasDp5RlmYQ5-JZh9FLKsW2iJeCC1lH0TIsVBlKCNblOZ1WxXU9matdOgi9OEIgWLuEHnp2jFY3Yr9YYQtZyHbHZDbzfB_ZzoRMYExXuAXuc14ogGVal4FpVlVFKpcImZqOZVlmnbNBNhSAREwT1c3BijgrH0OdIRZDDADXxgqfAQApa8_ZRKipMBEyhw15qCXbX9nEbYdhwW90Mf0x8WzLn0wMp2ENvN_3xNtRp80RbEMZGkFttoMiNPKJPfXAN7LHZOpMjZFH3IkN5oz4tgcZbOJ5iIPDJdbEGDkQvtnoEcsH-JRY09nZgiC-ZUOSGgc95NDPwbYlAG3ie4D0obkubHQ94swgzwxyNqSa6R2cRIR6bh21lllHrOfVxu9ZtTRaTu38zKgn1BXSE3pddp8RujRs3vXcrM_mcphmf5r9WZuDw56zPExpj80kTTrRKFBNEirND6RkkdrmpMyEFspksemM_VpGpmtZZFOmH7I8jBaP019bb3bzqXq6u9t8vp08OvffHKofnp65-LJ2ntY8_-mz_XL00EnvTcm_JXqESkkVlTv6UZU00l9DzQTQ3D-w-Af8keIsopegfb0A2Up-9a7T71li0KGm6r4FQyknjHPYV4hiEFBpKV4ouKuM6T_839saxme2_-4q_L8Gf3UNhldgXr_rYAaqZ7trbGBRgnoKhYMjbtSHAx_e3LiVHQ682ojpepviIAm5ogamudiw50NZf2t01VgQJ4EPyG2-pjEOtNzSk4F1uAZERjkXlZA8xqff). See this comment for [explanation](https://github.com/vercel/satori/issues/650#issuecomment-2506776490) of why this is happening.

## Proposed behavior

Try changing the background color in this branch's [playground link](https://satori-playground-git-fork-erxclau-clear-image-inflight-6f2758.vercel.sh/?share=7VVdb9owFP0rlvfSScH5BEIEnVZUqZ3UrZ2qTZN4CYmTmDpxZhsCQ_z33XxBqvVp2uOMUHyvj-899_o4OeJIxBQHeB6z3apASOkDp4vjsZ4jFDNV8vAQoBVOON2vsNH6N1ulWXJYikLTQtfLETypPANCztLiXtNcvVpE7WrFYp0FyLasDp5RlmYQ5-JZh9FLKsW2iJeCC1lH0TIsVBlKCNblOZ1WxXU9matdOgi9OEIgWLuEHnp2jFY3Yr9YYQtZyHbHZDbzfB_ZzoRMYExXuAXuc14ogGVal4FpVlVFKpcImZqOZVlmnbNBNhSAREwT1c3BijgrH0OdIRZDDADXxgqfAQApa8_ZRKipMBEyhw15qCXbX9nEbYdhwW90Mf0x8WzLn0wMp2ENvN_3xNtRp80RbEMZGkFttoMiNPKJPfXAN7LHZOpMjZFH3IkN5oz4tgcZbOJ5iIPDJdbEGDkQvtnoEcsH-JRY09nZgiC-ZUOSGgc95NDPwbYlAG3ie4D0obkubHQ94swgzwxyNqSa6R2cRIR6bh21lllHrOfVxu9ZtTRaTu38zKgn1BXSE3pddp8RujRs3vXcrM_mcphmf5r9WZuDw56zPExpj80kTTrRKFBNEirND6RkkdrmpMyEFspksemM_VpGpmtZZFOmH7I8jBaP019bb3bzqXq6u9t8vp08OvffHKofnp65-LJ2ntY8_-mz_XL00EnvTcm_JXqESkkVlTv6UZU00l9DzQTQ3D-w-Af8keIsopegfb0A2Up-9a7T71li0KGm6r4FQyknjHPYV4hiEFBpKV4ouKuM6T_839saxme2_-4q_L8Gf3UNhldgXr_rYAaqZ7trbGBRgnoKhYMjbtSHAx_e3LiVHQ682ojpepviIAm5ogamudiw50NZf2t01VgQJ4EPyG2-pjEOtNzSk4F1uAZERjkXlZA8xqff).

## Related

This is related to #593 and #592 (https://github.com/vercel/satori/issues/592#issuecomment-1979586066 and https://github.com/vercel/satori/issues/592#issuecomment-1979590654).

The error in #592 is no longer thrown, though the image still does not render in PNG mode ([link](https://satori-playground-git-fork-erxclau-clear-image-inflight-6f2758.vercel.sh/?share=7VVdb9owFP0rlvfSScH5BEIEnVZUqZ3UrZ2qTZN4CYmTmDpxZhsCQ_z33XxBqvVp2uOMUHyvj-899_o4OeJIxBQHeB6z3apASOkDp4vjsZ4jFDNV8vAQoBVOON2vsNH6N1ulWXJYikLTQtfLETypPANCztLiXtNcvVpE7WrFYp0FyLasDp5RlmYQ5-JZh9FLKsW2iJeCC1lH0TIsVBlKCNblOZ1WxXU9matdOgi9OEIgWLuEHnp2jFY3Yr9YYQtZyHbHZDbzfB_ZzoRMYExXuAXuc14ogGVal4FpVlVFKpcImZqOZVlmnbNBNhSAREwT1c3BijgrH0OdIRZDDADXxgqfAQApa8_ZRKipMBEyhw15qCXbX9nEbYdhwW90Mf0x8WzLn0wMp2ENvN_3xNtRp80RbEMZGkFttoMiNPKJPfXAN7LHZOpMjZFH3IkN5oz4tgcZbOJ5iIPDJdbEGDkQvtnoEcsH-JRY09nZgiC-ZUOSGgc95NDPwbYlAG3ie4D0obkubHQ94swgzwxyNqSa6R2cRIR6bh21lllHrOfVxu9ZtTRaTu38zKgn1BXSE3pddp8RujRs3vXcrM_mcphmf5r9WZuDw56zPExpj80kTTrRKFBNEirND6RkkdrmpMyEFspksemM_VpGpmtZZFOmH7I8jBaP019bb3bzqXq6u9t8vp08OvffHKofnp65-LJ2ntY8_-mz_XL00EnvTcm_JXqESkkVlTv6UZU00l9DzQTQ3D-w-Af8keIsopegfb0A2Up-9a7T71li0KGm6r4FQyknjHPYV4hiEFBpKV4ouKuM6T_839saxme2_-4q_L8Gf3UNhldgXr_rYAaqZ7trbGBRgnoKhYMjbtSHAx_e3LiVHQ682ojpepviIAm5ogamudiw50NZf2t01VgQJ4EPyG2-pjEOtNzSk4F1uAZERjkXlZA8xqff)).