### PR TITLE
fix: handle z-index as unitless property

### DIFF
--- a/src/handler/expand.ts
+++ b/src/handler/expand.ts
@@ -59,6 +59,13 @@ function handleSpecialCase(
   value: string | number,
   currentColor: string
 ) {
+  if (name === 'zIndex') {
+    console.warn(
+      'z-index is not supported in SVG. Elements are painted in the order they appear in the document.'
+    )
+    return { [name]: value }
+  }
+
   if (name === 'lineHeight') {
     return { lineHeight: purify(name, value) }
   }


### PR DESCRIPTION
## Description

### Current behavior:
When setting z-index values in styles, a warning appears stating "Expected style 'zIndex: 1px' to be unitless". This warning is incorrect since z-index should be handled as a unitless property. While z-index has no effect in SVG (as elements are painted in document order), the warning itself needs to be fixed for better developer experience.

### Changes in this PR:
- Added special case handling for `zIndex` property
- Added clear warning message explaining that z-index is not supported in SVG
- Improved developer experience by providing more accurate feedback about SVG limitations

Closes #660

## Test plan

### Before
The floating warning appears in console when setting z-index:
```javascript
style={{
  zIndex: 1
}}
```
Shows warning: "Expected style 'zIndex: 1px' to be unitless"

![image](https://github.com/user-attachments/assets/4833bbb7-4794-4c05-baff-bab6c645399e)


### After
1. Set z-index in styles
2. Verify the correct warning appears: "z-index is not supported in SVG. Elements are painted in the order they appear in the document."
3. Test with different z-index values
4. Verify the warning is clear and helpful for developers

![image](https://github.com/user-attachments/assets/caf51676-85f4-429d-a687-4c3e65a9d063)
