### PR TITLE
fix: text align justify not working

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -220,7 +220,7 @@ export default async function* buildTextNodes(
       }
 
       const allowedToPutAtBeginning = ',.!?:-@)>]}%#'.indexOf(word[0]) < 0
-      const allowedToJustify = !currentWidth
+      const allowedToJustify = textAlign === 'justify'
 
       const willWrap =
         i &&


### PR DESCRIPTION
Closes https://github.com/vercel/satori/issues/670.

**Overview**
This pull request fixes a bug related to `textAlign: justify` not working.

Current behavior:
![Screenshot from 2025-05-18 14-59-31](https://github.com/user-attachments/assets/f146c70a-0e69-446f-870d-e884dbaf5bad)
https://og-playground.vercel.app/?share=HY_LTsMwEEV_ZTSbbixIW16ySiUWSOyBD0jqSTyVX8QT0hDl33Gym3M1uo8ZL9EQajwlyDI5ep1nuEQXew270bLQTsHIRmzh43OVboWFbvLmuAtFuw5ZuJ2K2sYgn_xHGh5eFDgO9EHcWdGwvzs8KliW87cABfZQG_C8Hr8Fa6_gZ-AMp_t0RoUxCceQUc-4BaPeH6pKod3cUD8dCxhqhg51W7tMCsnHK39NaR0i40bFaC307hsyqKUfaFEodVM-LDkXx9g7g8s_


**Expceted behavior:**
![Screenshot from 2025-05-18 15-01-41](https://github.com/user-attachments/assets/10c21682-ad11-428e-8b4a-3c74b6017804)


