### PR TITLE
feat: Cache font resolver (3%~4% faster depending on number of text nodes)

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -95,6 +95,8 @@ const cachedParsedFont = new WeakMap<
 export default class FontLoader {
   defaultFont: opentype.Font
   fonts = new Map<string, [opentype.Font, Weight?, FontStyle?][]>()
+  cachedFontResolver = new Map<number, opentype.Font | undefined>()
+
   constructor(fontOptions: FontOptions[]) {
     this.addFonts(fontOptions)
   }
@@ -287,7 +289,6 @@ export default class FontLoader {
       }
     }
 
-    const cachedFontResolver = new Map<number, opentype.Font | undefined>()
     const resolveFont = (word: string, fallback = true) => {
       const _fonts = [
         ...fonts,
@@ -304,7 +305,8 @@ export default class FontLoader {
       }
 
       const code = word.charCodeAt(0)
-      if (cachedFontResolver.has(code)) return cachedFontResolver.get(code)
+      if (this.cachedFontResolver.has(code))
+        return this.cachedFontResolver.get(code)
 
       const font = _fonts.find((_font, index) => {
         return (
@@ -314,7 +316,7 @@ export default class FontLoader {
       })
 
       if (font) {
-        cachedFontResolver.set(code, font)
+        this.cachedFontResolver.set(code, font)
       }
 
       return font


### PR DESCRIPTION
TODO: This should be an LRU to reduce memory impact.

Before:

<img width="1090" height="632" alt="CleanShot 2025-10-30 at 20 48 15@2x" src="https://github.com/user-attachments/assets/b69df903-4c4b-4985-a0f3-62daffd3ea57" />

After:

<img width="1086" height="638" alt="CleanShot 2025-10-30 at 20 48 25@2x" src="https://github.com/user-attachments/assets/cc8730d4-2bd5-475a-9a08-97d2703a046f" />
