### PR TITLE
chore: Export InitInput type and allow Promise as the init parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "exports": {
     "./package.json": "./package.json",
+    "./yoga.wasm": "./yoga.wasm",
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"

--- a/src/yoga.external.ts
+++ b/src/yoga.external.ts
@@ -16,25 +16,29 @@ const yogaPromise: Promise<Yoga> = new Promise((resolve, reject) => {
 })
 
 export type InitInput =
-  | RequestInfo
+  | string
+  | Request
   | URL
   | Response
   | BufferSource
   | Buffer
   | WebAssembly.Module
+  | Promise<Response | BufferSource | Buffer | WebAssembly.Module>
 
 async function loadWasm(
   input: InitInput,
   imports: WebAssembly.Imports
 ): Promise<WebAssembly.WebAssemblyInstantiatedSource> {
-  let source: Response | BufferSource | Buffer | WebAssembly.Module = input
+  let source: Response | BufferSource | Buffer | WebAssembly.Module
 
   if (
-    typeof source === 'string' ||
-    (typeof Request === 'function' && source instanceof Request) ||
-    (typeof URL === 'function' && source instanceof URL)
+    typeof input === 'string' ||
+    (typeof Request === 'function' && input instanceof Request) ||
+    (typeof URL === 'function' && input instanceof URL)
   ) {
-    source = await fetch(source)
+    source = await fetch(input)
+  } else {
+    source = await input
   }
 
   if (typeof Response === 'function' && source instanceof Response) {

--- a/src/yoga.ts
+++ b/src/yoga.ts
@@ -2,7 +2,7 @@ import { type Yoga } from 'yoga-layout/load'
 import { type Node } from 'yoga-layout'
 import { type InitInput } from './yoga.external.js'
 
-export { Yoga as TYoga, Node as YogaNode }
+export { Yoga as TYoga, Node as YogaNode, type InitInput }
 
 export function init(input: InitInput) {
   if (process.env.SATORI_STANDALONE === '1') {


### PR DESCRIPTION
* allows Promise as input, so we can
```ts
await init(fetch("yoga.wasm"));

// instead of

await init(await fetch("yoga.wasm"));
```
* exports `InitInput` type
* adds `./yoga.wasm` in `package.json` exports