### PR TITLE
feat: Support for mask-mode

### DIFF
--- a/src/builder/mask-image.ts
+++ b/src/builder/mask-image.ts
@@ -45,7 +45,15 @@ export default async function buildMaskImage(
       })
   }
 
-  mask = buildXMLString('mask', { id: miId }, mask)
+  const mode = maskImage[0]?.mode
+  const maskType =
+    mode === 'alpha' ? 'alpha' : mode === 'luminance' ? 'luminance' : undefined
+
+  mask = buildXMLString(
+    'mask',
+    { id: miId, ...(maskType ? { 'mask-type': maskType } : {}) },
+    mask
+  )
 
   return [miId, mask]
 }

--- a/src/parser/mask.ts
+++ b/src/parser/mask.ts
@@ -13,6 +13,7 @@ export interface MaskProperty {
   repeat: string
   origin: string
   clip: string
+  mode: string
 }
 
 export function parseMask(
@@ -26,6 +27,7 @@ export function parseMask(
     repeat: getMaskProperty(style, 'repeat') || 'repeat',
     origin: getMaskProperty(style, 'origin') || 'border-box',
     clip: getMaskProperty(style, 'origin') || 'border-box',
+    mode: getMaskProperty(style, 'mode') || 'match-source',
   }
 
   let maskImages = splitEffects(maskImage).filter((v) => v && v !== 'none')

--- a/test/mask-image.test.tsx
+++ b/test/mask-image.test.tsx
@@ -210,6 +210,34 @@ describe('Mask-*', () => {
     expect(toImage(svg, 100)).toMatchImageSnapshot()
   })
 
+  it('should support mask-mode', async () => {
+    const svgs = await Promise.all(
+      (['alpha', 'luminance', 'match-source'] as const).map((maskMode) =>
+        satori(
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              backgroundImage: `url(${PNG_SAMPLE})`,
+              maskImage: 'linear-gradient(to right, blue, transparent)',
+              maskMode,
+            }}
+          ></div>,
+          { width: 100, height: 100, fonts }
+        )
+      )
+    )
+
+    expect(svgs[0]).toContain('mask-type="alpha"')
+    expect(svgs[1]).toContain('mask-type="luminance"')
+    expect(svgs[2]).not.toContain('mask-type=')
+
+    svgs.forEach((svg) => {
+      expect(toImage(svg, 100)).toMatchImageSnapshot()
+    })
+  })
+
   it('should support mask-image on positioned elements', async () => {
     const svg = await satori(
       <div


### PR DESCRIPTION
Adds support for the [mask-mode property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/mask-mode), which controls whether a mask-image is interpreted as an alpha mask or a luminescence mask.

## Implementation
- `parseMask` reads `mask-mode` (and the `-webkit- prefixed` variant) and stores it on the parsed mask, defaulting to `match-source`.
- `buildMaskImage` emits `mask-type="alpha"` or `mask-type="luminance"` on the SVG mask element when explicitly set. For `match-source` no attribute is emitted, falling back to the default (luminance), preserving
   the existing rendering behavior.
   
Following the existing convention in `parseMask` (where position, size, repeat, origin, and clip apply as a single value to all layers), `maskMode` also applies once per element rather than per-layer. This maps cleanly onto SVGs per-<mask> mask-type attribute.

## Testing
 I have added a test which checks that `mask-type=` is properly applied to the SVG. There should probably be a pixel snapshot test added but I couldn't figure out how to do that, will add if required. All existing tests pass.