### PR TITLE
ci: declare minimum permissions on PR title workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Declares `permissions: contents: read, pull-requests: read` at the workflow level. The job's single step runs a PR-title validator (`amannn/action-semantic-pull-request` or equivalent) which reads the PR title via the pulls API and reports the result as the workflow's own check status. That needs read on `pull-requests` and nothing else.

The reason to be explicit even when the inherited default may already be reasonable is CVE-2025-30066, the March 2025 `tj-actions/changed-files` compromise where a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs. The leaked token carried whatever scope was issued at the workflow level, so per-workflow caps bound the runtime blast radius regardless of repo or org default. The block also gives drift protection if that default ever widens and is what OpenSSF Scorecard's Token-Permissions check looks for.

YAML validated locally with `yaml.safe_load`.
