### PR TITLE
fix: text matching Object.prototype property names silently not rendered (closes #746)

### DIFF
--- a/src/satori.ts
+++ b/src/satori.ts
@@ -73,7 +73,14 @@ export default async function satori(
   root.setJustifyContent(Yoga.JUSTIFY_FLEX_START)
   root.setOverflow(Yoga.OVERFLOW_HIDDEN)
 
-  const graphemeImages = { ...options.graphemeImages }
+  // Null-prototype object so that `graphemeImages[text]` lookups for strings
+  // that match `Object.prototype` property names (e.g. "constructor",
+  // "toString", "valueOf") return `undefined` instead of inherited methods.
+  // See https://github.com/vercel/satori/issues/746.
+  const graphemeImages: Record<string, string> = Object.assign(
+    Object.create(null),
+    options.graphemeImages
+  )
   // Some Chinese characters have different glyphs in Chinese and
   // Japanese, but their Unicode is the same. If the user needs to display
   // the Chinese and Japanese characters simultaneously correctly, the user

--- a/test/emoji.test.tsx
+++ b/test/emoji.test.tsx
@@ -116,4 +116,18 @@ describe('Emojis', () => {
 
     expect(await toImage(svg)).toMatchImageSnapshot()
   })
+
+  // https://github.com/vercel/satori/issues/746
+  it('should render text that matches Object.prototype property names', async () => {
+    const svg = await satori(<div>constructor toString valueOf</div>, {
+      width: 200,
+      height: 100,
+      fonts,
+    })
+    // The text used to be silently replaced with the inherited prototype
+    // method, e.g. `<image href="function Object() { [native code] }" .../>`.
+    expect(svg).not.toContain('[native code]')
+    expect(svg).not.toContain('[object Object]')
+    expect(svg).not.toContain('<image ')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #746.

`graphemeImages` was created as a plain object via `{ ...options.graphemeImages }`, which means it inherits from `Object.prototype`. When the text being rendered exactly matches an inherited property name (e.g. \`constructor\`, \`toString\`, \`valueOf\`, \`hasOwnProperty\`), the lookup `graphemeImages[text]` returned the inherited method instead of \`undefined\`. Downstream code then treated that function as an image URL and emitted \`<image href=\"function Object() { [native code] }\" ...>\` in the SVG output instead of rendering the text as glyph paths.

## Repro (from the issue)

```js
await satori({ type: 'div', props: { children: 'constructor' } }, { width: 600, height: 100, fonts: [...] })
// Before: <image href=\"function Object() { [native code] }\" .../>
// After:  <path d=\"...\"> (text rendered as glyph paths)
```

Affected strings: any exact match of an \`Object.prototype\` property — \`constructor\`, \`toString\`, \`valueOf\`, \`hasOwnProperty\`, \`isPrototypeOf\`, \`propertyIsEnumerable\`, \`toLocaleString\`, \`__proto__\`. Real-world example from the issue: titles containing the word \"constructor\" silently dropped from OGP images.

## Fix

Change the backing storage in \`src/satori.ts\` from \`{ ...options.graphemeImages }\` to \`Object.assign(Object.create(null), options.graphemeImages)\`. The resulting object has no prototype, so bracket lookups for non-own properties return \`undefined\` as expected, and the text falls through to the normal glyph-rendering path. No behaviour change for legitimate user-provided emoji/image keys.

## Test plan

- [x] Added a case in \`test/emoji.test.tsx\` that renders \`constructor toString valueOf\` without any graphemeImages and asserts the SVG contains no \`[native code]\`, \`[object Object]\`, or \`<image>\` element.
- [x] All existing emoji, basic, and error tests continue to pass (22 passing across the three files).