### PR TITLE
fix: render text matching Object.prototype property names as glyphs

### DIFF
--- a/src/satori.ts
+++ b/src/satori.ts
@@ -73,7 +73,10 @@ export default async function satori(
   root.setJustifyContent(Yoga.JUSTIFY_FLEX_START)
   root.setOverflow(Yoga.OVERFLOW_HIDDEN)
 
-  const graphemeImages = { ...options.graphemeImages }
+  // Use a null-prototype object so that text matching Object.prototype property
+  // names (e.g. "constructor", "toString") doesn't inherit truthy values from
+  // the prototype chain when we look it up via `graphemeImages[text]`.
+  const graphemeImages = Object.assign(Object.create(null), options.graphemeImages)
   // Some Chinese characters have different glyphs in Chinese and
   // Japanese, but their Unicode is the same. If the user needs to display
   // the Chinese and Japanese characters simultaneously correctly, the user

--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -216,4 +216,23 @@ describe('Basic', () => {
     )
     expect(toImage(svg, 100)).toMatchImageSnapshot()
   })
+
+  // https://github.com/vercel/satori/issues/746
+  it('should render text matching Object.prototype property names as glyphs, not images', async () => {
+    for (const word of [
+      'constructor',
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      '__proto__',
+    ]) {
+      const svg = await satori(<div>{word}</div>, {
+        width: 200,
+        height: 50,
+        fonts,
+      })
+      expect(svg).not.toMatch(/<image\b/)
+      expect(svg).toMatch(/<path\b/)
+    }
+  })
 })


### PR DESCRIPTION
Fixes #746.

When the text content exactly matches a property name that exists on `Object.prototype` (e.g. `constructor`, `toString`, `valueOf`, `hasOwnProperty`), Satori silently renders an `<image>` element with an invalid `href` instead of the expected glyph paths.

The cause is in `src/satori.ts`: `graphemeImages` is created with `{ ...options.graphemeImages }`, which produces a plain object that inherits from `Object.prototype`. Two later sites in `src/text/index.ts` look up entries with bracket notation (`graphemeImages[s]` at line 122 and `graphemeImages[text]` at line 554). When the text is `"constructor"`, the lookup returns the inherited `Function` value instead of `undefined`, the value coerces to truthy, and the word gets routed through the image rendering branch.

The fix is one line: build the dictionary on a null-prototype base via `Object.assign(Object.create(null), options.graphemeImages)`. Bracket lookups now only see user-provided keys, so unrelated text falls through correctly. The existing emoji tests still pass since `Object.assign` and the later `Object.assign(graphemeImages, images)` in the `loadAdditionalAsset` path both work fine with null-prototype targets.

Added a regression test in `test/basic.test.tsx` covering `constructor`, `toString`, `valueOf`, `hasOwnProperty`, and `__proto__`. It asserts the SVG contains a `<path>` element and no `<image>` element. Verified the test fails on `main` and passes with the fix applied.