### PR TITLE
docs: fix flexWrap default from 'wrap' to 'nowrap'

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Satori uses the same Flexbox [layout engine](https://yogalayout.com) as React Na
 
 <tr><td rowspan="11">Flex</td></tr>
 <tr><td><code>flexDirection</code></td><td><code>column</code>, <code>row</code>, <code>row-reverse</code>, <code>column-reverse</code>, default to <code>row</code></td><td></td></tr>
-<tr><td><code>flexWrap</code></td><td><code>wrap</code>, <code>nowrap</code>, <code>wrap-reverse</code>, default to <code>wrap</code></td><td></td></tr>
+<tr><td><code>flexWrap</code></td><td><code>wrap</code>, <code>nowrap</code>, <code>wrap-reverse</code>, default to <code>nowrap</code></td><td></td></tr>
 <tr><td><code>flexGrow</code></td><td>Supported</td><td></td></tr>
 <tr><td><code>flexShrink</code></td><td>Supported</td><td></td></tr>
 <tr><td><code>flexBasis</code></td><td>Supported except for <code>auto</code></td><td></td></tr>


### PR DESCRIPTION
## Problem (#759)

The README's CSS-support table documents the default value of `flexWrap` as `wrap`, but the actual implementation in `src/handler/compute.ts` defaults to `nowrap` (`Yoga.WRAP_NO_WRAP`), matching the CSS spec.

## Fix

One-line change in `README.md`: `default to wrap` -> `default to nowrap`