### PR TITLE
fix: text matching Object.prototype property names rendered as image

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -119,7 +119,11 @@ export default async function* buildTextNodes(
   }
 
   function isImage(s: string): boolean {
-    return !!(graphemeImages && graphemeImages[s])
+    return !!(
+      graphemeImages &&
+      Object.prototype.hasOwnProperty.call(graphemeImages, s) &&
+      graphemeImages[s]
+    )
   }
 
   const { measureGrapheme, measureGraphemeArray, measureText } = genMeasurer(
@@ -551,7 +555,11 @@ export default async function* buildTextNodes(
     let path: string | null = null
     let isLastDisplayedBeforeEllipsis = false
 
-    const image = graphemeImages ? graphemeImages[text] : null
+    const image =
+      graphemeImages &&
+      Object.prototype.hasOwnProperty.call(graphemeImages, text)
+        ? graphemeImages[text]
+        : null
 
     let topOffset = layout.y
     let leftOffset = layout.x


### PR DESCRIPTION
## Problem (#746)

When text content passed to Satori **exactly matched** an `Object.prototype` property name (e.g. `"constructor"`, `"toString"`, `"valueOf"`), the text was silently not rendered. Instead, an `<image>` element with an invalid `href` was emitted.

### Root Cause

Two locations in `src/text/index.ts` used bracket-notation lookup on a user-provided `graphemeImages` object:

1. `isImage(s)` (line 122): `graphemeImages[s]` — when `s` is `"constructor"`, this returns `Object.prototype.constructor` (a truthy function), so the text was incorrectly treated as an image.

2. Rendering path (line 558): `graphemeImages[text]` — same issue, returns the inherited property instead of `undefined`.

### Fix

Use `Object.prototype.hasOwnProperty.call()` to check for own properties before accessing the value:

```ts
// Before
graphemeImages[s]

// After
Object.prototype.hasOwnProperty.call(graphemeImages, s) && graphemeImages[s]
```

### Testing

All 433 existing tests pass. The fix only affects edge cases where text exactly matches `Object.prototype` property names — normal usage is unaffected.