### PR TITLE
fix: accept JSX-like element objects

### DIFF
--- a/src/handler/preprocess.ts
+++ b/src/handler/preprocess.ts
@@ -2,6 +2,7 @@ import type { ReactElement, ReactNode, Fragment } from 'react'
 import { Fragment as FragmentSymbol } from '../jsx/jsx-runtime.js'
 import { resolveImageData, cache } from './image.js'
 import { isReactElement, parseViewBox, midline } from '../utils.js'
+import type { SatoriElement, SatoriRenderable } from '../utils.js'
 
 // Based on
 // https://raw.githubusercontent.com/facebook/react/master/packages/react-dom/src/shared/possibleStandardNames.js
@@ -154,9 +155,9 @@ function translateSVGNodeToSVGString(
  * @param node ReactNode
  * @returns
  */
-export async function preProcessNode(node: ReactNode) {
+export async function preProcessNode(node: SatoriRenderable) {
   const set = new Set<string | Buffer | ArrayBuffer>()
-  const walk = (_node: ReactNode) => {
+  const walk = (_node: SatoriRenderable) => {
     if (!_node) return
     if (!isReactElement(_node)) return
 
@@ -195,7 +196,7 @@ export async function preProcessNode(node: ReactNode) {
 }
 
 export async function SVGNodeToImage(
-  node: ReactElement,
+  node: ReactElement | SatoriElement,
   inheritedColor: string
 ): Promise<string> {
   let {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -2,7 +2,6 @@
  * This module is used to calculate the layout of the current sub-tree.
  */
 
-import type { ReactNode } from 'react'
 import {
   isReactElement,
   isClass,
@@ -12,6 +11,7 @@ import {
   isReactComponent,
   isForwardRefComponent,
 } from './utils.js'
+import type { SatoriRenderable } from './utils.js'
 import { getYoga, YogaNode } from './yoga.js'
 import { SVGNodeToImage } from './handler/preprocess.js'
 import computeStyle from './handler/compute.js'
@@ -44,13 +44,13 @@ export interface SatoriNode {
   width: number
   height: number
   type: string
-  key?: string | number
+  key?: string | number | bigint
   props: Record<string, any>
   textContent?: string
 }
 
 export default async function* layout(
-  element: ReactNode,
+  element: SatoriRenderable,
   context: LayoutContext
 ): AsyncGenerator<
   { word: string; locale?: string }[],

--- a/src/satori.ts
+++ b/src/satori.ts
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react'
 import type { TwConfig } from 'twrnc'
 import type { SatoriNode } from './layout.js'
 
@@ -11,6 +10,7 @@ import getTw from './handler/tailwind.js'
 import { preProcessNode } from './handler/preprocess.js'
 import { cache, inflightRequests } from './handler/image.js'
 import { segment } from './utils.js'
+import type { SatoriRenderable } from './utils.js'
 
 // We don't need to initialize the opentype instances every time.
 const fontCache = new WeakMap()
@@ -42,7 +42,7 @@ export type SatoriOptions = (
 export type { SatoriNode }
 
 export default async function satori(
-  element: ReactNode,
+  element: SatoriRenderable,
   options: SatoriOptions
 ): Promise<string> {
   const Yoga = await getYoga()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,17 @@ import LineBreaker from 'linebreak'
 
 import CssDimension from './vendor/parse-css-dimension/index.js'
 
-export function isReactElement(node: ReactNode): node is ReactElement {
+export interface SatoriElement {
+  type: string | Function
+  props: Record<string, any>
+  key?: string | number | bigint | null
+}
+
+export type SatoriRenderable = ReactNode | SatoriElement
+
+export function isReactElement(
+  node: SatoriRenderable
+): node is ReactElement | SatoriElement {
   const type = typeof node
   if (
     type === 'number' ||

--- a/test/jsx-runtime.test.tsx
+++ b/test/jsx-runtime.test.tsx
@@ -76,4 +76,23 @@ describe('Minimal JSX runtime', () => {
     })
     expect(toImage(svg, 100)).toMatchImageSnapshot()
   })
+
+  it('should accept JSX-like elements without a React key', async () => {
+    const svg = await satori(
+      {
+        type: 'div',
+        props: {
+          children: 'Hello from an object tree',
+          style: {
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+          },
+        },
+      },
+      { width: 100, height: 100, fonts }
+    )
+
+    expect(svg).toContain('<svg')
+  })
 })


### PR DESCRIPTION
## Summary

- Accept JSX-like element objects without React's required key property.
- Share the validated renderable type across Satori's public entry point, preprocessing, layout, and SVG conversion.
- Add a regression that renders an Astro-style object tree.

Fixes #765.

## Validation

- itest run test/jsx-runtime.test.tsx (3 passed)
- 	sc -p tsconfig.json --noEmit 
- ESLint and Prettier