### PR TITLE
fix: harden SSRF guard against trailing dots, redirects, and DNS

### DIFF
--- a/src/handler/image.ts
+++ b/src/handler/image.ts
@@ -140,7 +140,7 @@ function parsePNG(buf: ArrayBuffer) {
 }
 
 import { createLRU, parseViewBox } from '../utils.js'
-import { assertSafeServerFetchUrl } from './url-safety.js'
+import { safeServerFetch } from './url-safety.js'
 
 type ResolvedImageData = [string, number?, number?] | readonly []
 export const cache = createLRU<ResolvedImageData>(500)
@@ -334,14 +334,14 @@ export async function resolveImageData(
   }
 
   const url = src
-  // Block SSRF to private/loopback/link-local addresses before fetching.
-  // Server-only: in the browser, fetching localhost is the user's own machine,
-  // not a server-side request-forgery surface. Fails closed (throws), matching
-  // the absolute-URL validation above.
-  if (typeof window === 'undefined') {
-    assertSafeServerFetchUrl(url)
-  }
-  const promise = fetch(url)
+  // Server-only SSRF guard: literal host + DNS (when node:dns exists) +
+  // per-hop redirect validation. In the browser, fetching localhost is the
+  // user's own machine — not a server-side request-forgery surface.
+  const doFetch =
+    typeof window === 'undefined'
+      ? () => safeServerFetch(url)
+      : () => fetch(url)
+  const promise = doFetch()
     .then((res): Promise<string | ArrayBuffer> => {
       const type = res.headers.get('content-type')
 
@@ -372,6 +372,11 @@ export async function resolveImageData(
       return result
     })
     .catch((err) => {
+      // SSRF blocks must fail closed to the caller — do not cache an empty
+      // result that would mask a blocked internal URL as a missing image.
+      if (err instanceof Error && err.message.includes('SSRF protection')) {
+        throw err
+      }
       console.error(`Can't load image ${url}: ` + err.message)
       cache.set(url, [])
       return [] as const

--- a/src/handler/url-safety.ts
+++ b/src/handler/url-safety.ts
@@ -237,7 +237,13 @@ async function getDnsLookup(): Promise<DnsLookup | null> {
     return null
   }
   try {
-    const dns = await import('node:dns/promises')
+    // Indirect import so Webpack/Next (playground) cannot statically resolve
+    // the `node:` builtin when bundling dist/ for the browser. esbuild also
+    // strips `/* webpackIgnore: true */`, so a literal import() is unsafe.
+    const load = new Function('s', 'return import(s)') as (
+      s: string
+    ) => Promise<typeof import('node:dns/promises')>
+    const dns = await load('node:dns/promises')
     dnsLookup = (hostname, options) => dns.lookup(hostname, options)
     return dnsLookup
   } catch {

--- a/src/handler/url-safety.ts
+++ b/src/handler/url-safety.ts
@@ -6,21 +6,25 @@
  * controls that URL can point it at internal addresses (`127.0.0.1`,
  * `169.254.169.254` cloud metadata, RFC-1918 ranges) and — because Satori
  * base64-inlines `image/svg+xml` responses into its output — read the body
- * back in-band. This blocks the unsafe address ranges before the fetch.
+ * back in-band.
  *
- * This is intentionally dependency-free and runtime-agnostic (browser, edge,
- * Node) — it cannot use `node:dns`/`node:net`, so it only classifies the
- * literal host. WHATWG `URL` normalizes obfuscated IPv4 forms
- * (`http://0x7f.1`, `http://2130706433`) to dotted-decimal for us, closing the
- * classic blocklist bypasses.
+ * Layers:
+ *  1. Literal-host classification (all runtimes) — blocks private IPs,
+ *     localhost, `.local` / `.internal`, and embedded-IPv4 IPv6 forms.
+ *  2. Per-hop redirect validation — `fetch` is called with `redirect:
+ *     'manual'` so a public URL cannot bounce to an internal Location.
+ *  3. DNS resolution when `node:dns` is available — rejects hostnames that
+ *     resolve to a private address. Residual DNS-rebinding (IP flips between
+ *     lookup and connect) still needs a connect-time-pinning fetcher
+ *     (e.g. `@vercel/safe-fetch`) or egress controls.
  *
- * ponytail: literal-host classification only; a hostname that *resolves* to a
- * private IP (DNS rebinding) is not covered here. Hosts needing full coverage
- * should run Satori behind an SSRF-safe fetcher (e.g. `@vercel/safe-fetch`,
- * which DNS-resolves and pins the connect-time IP).
+ * WHATWG `URL` normalizes obfuscated IPv4 (`http://0x7f.1`, `http://2130706433`)
+ * to dotted-decimal for us.
  */
 
 const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+const MAX_REDIRECTS = 10
+const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308])
 
 /**
  * IPv4 ranges unsafe for server-side outbound fetches: `0.0.0.0/8`,
@@ -51,83 +55,286 @@ function isUnsafeIpv4(v4: string): boolean {
 }
 
 /**
+ * Expands an IPv6 literal into 8 16-bit groups, handling `::` compression and
+ * an optional dotted-decimal IPv4 tail. Returns null if unparseable.
+ */
+function parseIpv6(ip: string): number[] | null {
+  let address = ip
+  const zone = address.indexOf('%')
+  if (zone !== -1) address = address.slice(0, zone)
+
+  const halves = address.split('::')
+  if (halves.length > 2) return null
+
+  const toGroups = (segment: string): number[] | null => {
+    if (segment === '') return []
+    const groups: number[] = []
+    const parts = segment.split(':')
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      if (part.includes('.')) {
+        if (i !== parts.length - 1 || !IPV4_RE.test(part)) return null
+        const [a, b, c, d] = part.split('.').map((p) => Number.parseInt(p, 10))
+        if (
+          [a, b, c, d].some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+        ) {
+          return null
+        }
+        groups.push((a << 8) | b, (c << 8) | d)
+        continue
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null
+      groups.push(Number.parseInt(part, 16))
+    }
+    return groups
+  }
+
+  const head = toGroups(halves[0])
+  if (head === null) return null
+
+  if (halves.length === 2) {
+    const tail = toGroups(halves[1])
+    if (tail === null) return null
+    const fill = 8 - head.length - tail.length
+    if (fill < 0) return null
+    return [...head, ...new Array(fill).fill(0), ...tail]
+  }
+
+  return head.length === 8 ? head : null
+}
+
+/**
  * Decodes the IPv4 destination embedded in an IPv6 literal, or null if none.
  * Covers every form whose low 32 bits route to an IPv4 address:
- *   `::ffff:a.b.c.d` / `::ffff:HI:LO`   IPv4-mapped
- *   `64:ff9b::a.b.c.d` / `64:ff9b::HI:LO` NAT64 well-known prefix (RFC 6052)
- *   `::a.b.c.d` / `::HI:LO`             IPv4-compatible (deprecated)
- * WHATWG `URL` normalizes all of these to the hex `HI:LO` form; the dotted
- * branch is kept for non-normalized inputs. Scoped to these prefixes so a
- * public IPv6 whose low bits happen to look private isn't mis-decoded.
+ *   `::ffff:a.b.c.d` / `::ffff:HI:LO`           IPv4-mapped
+ *   `::ffff:0:a.b.c.d` / `::ffff:0:HI:LO`       IPv4-translated (SIIT)
+ *   `64:ff9b::a.b.c.d` / `64:ff9b::HI:LO`       NAT64 well-known prefix
+ *   `64:ff9b:1::…`                              NAT64 local-use prefix
+ *   `::a.b.c.d` / `::HI:LO`                     IPv4-compatible (deprecated)
  */
-function embeddedIpv4(host: string): string | null {
-  const dotted = host.match(
-    /^(?:::ffff:|64:ff9b::|::)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
-  )
-  if (dotted) return dotted[1]
+function embeddedIpv4(groups: number[]): string | null {
+  const topZero = (n: number) => groups.slice(0, n).every((g) => g === 0)
+  const embeds =
+    topZero(6) || // ::/96 IPv4-compatible
+    (topZero(5) && groups[5] === 0xffff) || // ::ffff:0:0/96 mapped
+    (topZero(4) && groups[4] === 0xffff && groups[5] === 0) || // translated
+    (groups[0] === 0x64 &&
+      groups[1] === 0xff9b &&
+      groups[2] === 0 &&
+      groups[3] === 0 &&
+      groups[4] === 0 &&
+      groups[5] === 0) || // 64:ff9b::/96
+    (groups[0] === 0x64 && groups[1] === 0xff9b && groups[2] === 1) // 64:ff9b:1::/48
 
-  const hex = host.match(
-    /^(?:::ffff:|64:ff9b::|::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/
-  )
-  if (hex) {
-    const hi = Number.parseInt(hex[1], 16)
-    const lo = Number.parseInt(hex[2], 16)
-    return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
-  }
-  return null
+  if (!embeds) return null
+  const a = (groups[6] >> 8) & 0xff
+  const b = groups[6] & 0xff
+  const c = (groups[7] >> 8) & 0xff
+  const d = groups[7] & 0xff
+  return `${a}.${b}.${c}.${d}`
 }
 
 /**
  * IPv6 ranges unsafe for server-side fetches. Embedded-IPv4 forms (mapped,
- * NAT64, compatible) are decoded and classified as IPv4. Host is already
- * lowercased with brackets stripped.
+ * translated, NAT64, compatible) are decoded and classified as IPv4. Host is
+ * already lowercased with brackets stripped.
  */
 function isUnsafeIpv6(host: string): boolean {
-  const v4 = embeddedIpv4(host)
+  const groups = parseIpv6(host)
+  if (groups === null) return true // unparseable — fail closed
+
+  const v4 = embeddedIpv4(groups)
   if (v4) return isUnsafeIpv4(v4)
 
-  if (host === '::' || host === '::1') return true // unspecified, loopback
-  if (host.startsWith('fc') || host.startsWith('fd')) return true // fc00::/7 ULA
-  if (/^fe[89ab]/.test(host)) return true // fe80::/10 link-local
-  if (/^fe[c-f]/.test(host)) return true // fec0::/10 site-local
-  if (host.startsWith('ff')) return true // ff00::/8 multicast
-  if (/^2001:0?db8(?::|$)/.test(host)) return true // 2001:db8::/32 docs
+  if (groups.every((g) => g === 0)) return true // ::
+  if (groups.slice(0, 7).every((g) => g === 0) && groups[7] === 1) return true // ::1
+  if ((groups[0] & 0xfe00) === 0xfc00) return true // fc00::/7 ULA
+  if ((groups[0] & 0xffc0) === 0xfe80) return true // fe80::/10 link-local
+  if ((groups[0] & 0xffc0) === 0xfec0) return true // fec0::/10 site-local
+  if ((groups[0] & 0xff00) === 0xff00) return true // ff00::/8 multicast
+  if (groups[0] === 0x2001 && groups[1] === 0xdb8) return true // 2001:db8::/32
   return false
 }
 
-/**
- * Returns `true` if Satori must refuse to `fetch()` this URL server-side.
- * Fails closed on anything it can't parse or classify as clearly public.
- */
-export function isUnsafeServerFetchUrl(rawUrl: string): boolean {
+/** Classify a raw IPv4/IPv6 address string (e.g. from `dns.lookup`). */
+export function isUnsafeIpAddress(address: string): boolean {
+  const host = address.toLowerCase().replace(/^\[|\]$/g, '')
+  if (IPV4_RE.test(host)) return isUnsafeIpv4(host)
+  if (host.includes(':')) return isUnsafeIpv6(host)
+  return true // not an IP — fail closed
+}
+
+function normalizeHostname(rawUrl: string): {
+  url: URL
+  host: string
+} | null {
   let url: URL
   try {
     url = new URL(rawUrl)
   } catch {
-    return true
+    return null
   }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
 
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') return true
-
-  let host = url.hostname.toLowerCase()
+  // Strip trailing dots so FQDNs like `localhost.` (WHATWG hostname stays
+  // `localhost.`) cannot bypass the hostname blocklist.
+  let host = url.hostname.toLowerCase().replace(/\.+$/, '')
   if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1)
+  if (!host) return null
+  return { url, host }
+}
+
+/**
+ * Returns `true` if Satori must refuse to `fetch()` this URL server-side based
+ * on the literal hostname / IP. Does not resolve DNS.
+ */
+export function isUnsafeServerFetchUrl(rawUrl: string): boolean {
+  const parsed = normalizeHostname(rawUrl)
+  if (!parsed) return true
+  const { host } = parsed
 
   if (host === 'localhost' || host.endsWith('.localhost')) return true
-  if (host.endsWith('.local')) return true
+  if (host === 'local' || host.endsWith('.local')) return true
+  // Cloud / corp DNS special-use: GCP metadata is `metadata.google.internal`.
+  if (host === 'internal' || host.endsWith('.internal')) return true
 
   if (IPV4_RE.test(host)) return isUnsafeIpv4(host)
   if (host.includes(':')) return isUnsafeIpv6(host)
 
-  // Regular hostname — DNS resolution isn't available in all runtimes, so we
-  // can't classify what it resolves to. Allowed (see ponytail note above).
   return false
 }
 
-/** Throws if `rawUrl` is unsafe for a server-side image fetch. */
+function ssrfError(rawUrl: string): Error {
+  return new Error(
+    `Image source resolves to a blocked address (SSRF protection): ${rawUrl}`
+  )
+}
+
+/** Throws if `rawUrl` is unsafe for a server-side image fetch (literal host). */
 export function assertSafeServerFetchUrl(rawUrl: string): void {
-  if (isUnsafeServerFetchUrl(rawUrl)) {
-    throw new Error(
-      `Image source resolves to a blocked address (SSRF protection): ${rawUrl}`
-    )
+  if (isUnsafeServerFetchUrl(rawUrl)) throw ssrfError(rawUrl)
+}
+
+type DnsLookup = (
+  hostname: string,
+  options: { all: true }
+) => Promise<Array<{ address: string; family: number }>>
+
+type SafeFetchOptions = {
+  /** Override DNS lookup (tests). `null` skips DNS. Default: node:dns when available. */
+  lookup?: DnsLookup | null
+  /** Override fetch (tests). Default: globalThis.fetch. */
+  fetch?: typeof globalThis.fetch
+}
+
+let dnsLookup: DnsLookup | null | undefined
+
+/** Lazy-load `node:dns/promises` when available; null in browser / edge. */
+async function getDnsLookup(): Promise<DnsLookup | null> {
+  if (dnsLookup !== undefined) return dnsLookup
+  if (typeof window !== 'undefined') {
+    dnsLookup = null
+    return null
   }
+  try {
+    const dns = await import('node:dns/promises')
+    dnsLookup = (hostname, options) => dns.lookup(hostname, options)
+    return dnsLookup
+  } catch {
+    dnsLookup = null
+    return null
+  }
+}
+
+/**
+ * Literal-host check, then (on Node) DNS-resolve and reject private answers.
+ * IP literals skip DNS. When `node:dns` is unavailable, falls back to literal
+ * checks only.
+ */
+export async function assertSafeServerFetchTarget(
+  rawUrl: string,
+  options?: SafeFetchOptions
+): Promise<void> {
+  assertSafeServerFetchUrl(rawUrl)
+
+  const parsed = normalizeHostname(rawUrl)
+  if (!parsed) throw ssrfError(rawUrl)
+  const { host } = parsed
+
+  // Already classified as a literal address above.
+  if (IPV4_RE.test(host) || host.includes(':')) return
+
+  const lookup =
+    options && 'lookup' in options ? options.lookup : await getDnsLookup()
+  if (!lookup) return
+
+  let records: Array<{ address: string; family: number }>
+  try {
+    records = await lookup(host, { all: true })
+  } catch {
+    // Resolver failure — do not fetch an unverified host.
+    throw new Error(`Can't resolve image host: ${rawUrl}`)
+  }
+
+  if (records.length === 0) {
+    throw new Error(`Can't resolve image host: ${rawUrl}`)
+  }
+
+  for (const { address } of records) {
+    if (isUnsafeIpAddress(address)) throw ssrfError(rawUrl)
+  }
+}
+
+/**
+ * Drain a response body so the underlying socket is released (important for
+ * redirect hops we are about to abandon or reject).
+ */
+async function cancelBody(res: Response): Promise<void> {
+  try {
+    if (res.body && typeof res.body.cancel === 'function') {
+      await res.body.cancel()
+    } else if (typeof res.arrayBuffer === 'function') {
+      await res.arrayBuffer()
+    }
+  } catch {
+    // ignore — best-effort drain
+  }
+}
+
+/**
+ * Server-side image `fetch` with SSRF controls: validates every hop (literal +
+ * DNS) and never follows redirects blindly.
+ */
+export async function safeServerFetch(
+  rawUrl: string,
+  options?: SafeFetchOptions
+): Promise<Response> {
+  const doFetch = options?.fetch ?? globalThis.fetch
+  let currentUrl = rawUrl
+
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    await assertSafeServerFetchTarget(currentUrl, options)
+
+    const response = await doFetch(currentUrl, { redirect: 'manual' })
+
+    // Spec-compliant fetch yields an opaque-redirect in browsers; we never
+    // call this helper in the browser (see image.ts), so treat it as unsafe.
+    if (response.type === 'opaqueredirect') {
+      await cancelBody(response)
+      throw ssrfError(currentUrl)
+    }
+
+    const location = response.headers.get('location')
+    if (REDIRECT_STATUS.has(response.status) && location) {
+      await cancelBody(response)
+      currentUrl = new URL(location, currentUrl).href
+      continue
+    }
+
+    return response
+  }
+
+  throw new Error(
+    `Image source redirected too many times (SSRF protection): ${rawUrl}`
+  )
 }

--- a/test/url-safety.test.ts
+++ b/test/url-safety.test.ts
@@ -1,4 +1,9 @@
-import { createServer, type Server } from 'node:http'
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http'
 import { it, describe, expect, afterEach } from 'vitest'
 
 import {
@@ -141,7 +146,7 @@ describe('safeServerFetch (redirects)', () => {
   })
 
   async function listen(
-    handler: Parameters<typeof createServer>[0]
+    handler: (req: IncomingMessage, res: ServerResponse) => void
   ): Promise<string> {
     server = createServer(handler)
     await new Promise<void>((resolve) =>

--- a/test/url-safety.test.ts
+++ b/test/url-safety.test.ts
@@ -1,6 +1,12 @@
-import { it, describe, expect } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { it, describe, expect, afterEach } from 'vitest'
 
-import { isUnsafeServerFetchUrl } from '../src/handler/url-safety.js'
+import {
+  isUnsafeServerFetchUrl,
+  isUnsafeIpAddress,
+  assertSafeServerFetchTarget,
+  safeServerFetch,
+} from '../src/handler/url-safety.js'
 
 describe('isUnsafeServerFetchUrl', () => {
   it('blocks the reported SSRF vectors', () => {
@@ -17,6 +23,39 @@ describe('isUnsafeServerFetchUrl', () => {
       'http://[::ffff:169.254.169.254]/', // IPv4-mapped IPv6
       'http://[64:ff9b::169.254.169.254]/', // NAT64 well-known prefix
       'http://[::127.0.0.1]/', // IPv4-compatible IPv6 (deprecated)
+    ]) {
+      expect(isUnsafeServerFetchUrl(url), url).toBe(true)
+    }
+  })
+
+  it('blocks trailing-dot hostnames (FQDN form of localhost / .local)', () => {
+    // WHATWG URL keeps the trailing root dot on hostnames (`localhost.`),
+    // which previously skipped `host === 'localhost'`.
+    for (const url of [
+      'http://localhost./',
+      'http://localhost.',
+      'http://evil.localhost./img.png',
+      'http://printer.local./',
+      'http://metadata.google.internal./',
+    ]) {
+      expect(isUnsafeServerFetchUrl(url), url).toBe(true)
+    }
+  })
+
+  it('blocks .internal hostnames (e.g. GCP metadata)', () => {
+    expect(isUnsafeServerFetchUrl('http://metadata.google.internal/')).toBe(
+      true
+    )
+    expect(isUnsafeServerFetchUrl('http://foo.internal/')).toBe(true)
+  })
+
+  it('blocks IPv4-translated and NAT64 local-use IPv6 forms', () => {
+    // WHATWG leaves these uncompressed; the old prefix regex missed them.
+    for (const url of [
+      'http://[::ffff:0:127.0.0.1]/', // IPv4-translated (SIIT)
+      'http://[::ffff:0:7f00:1]/',
+      'http://[64:ff9b:1::169.254.169.254]/', // NAT64 local-use
+      'http://[64:ff9b:1::a9fe:a9fe]/',
     ]) {
       expect(isUnsafeServerFetchUrl(url), url).toBe(true)
     }
@@ -43,5 +82,128 @@ describe('isUnsafeServerFetchUrl', () => {
     ]) {
       expect(isUnsafeServerFetchUrl(url), url).toBe(false)
     }
+  })
+})
+
+describe('isUnsafeIpAddress', () => {
+  it('classifies DNS answer addresses', () => {
+    expect(isUnsafeIpAddress('127.0.0.1')).toBe(true)
+    expect(isUnsafeIpAddress('169.254.169.254')).toBe(true)
+    expect(isUnsafeIpAddress('8.8.8.8')).toBe(false)
+    expect(isUnsafeIpAddress('::1')).toBe(true)
+    expect(isUnsafeIpAddress('2606:4700:4700::1111')).toBe(false)
+  })
+})
+
+describe('assertSafeServerFetchTarget (DNS)', () => {
+  it('rejects hostnames whose DNS answers are private', async () => {
+    await expect(
+      assertSafeServerFetchTarget('http://evil.example/', {
+        lookup: async () => [{ address: '127.0.0.1', family: 4 }],
+      })
+    ).rejects.toThrow(/SSRF protection/)
+
+    await expect(
+      assertSafeServerFetchTarget('http://meta.example/', {
+        lookup: async () => [{ address: '169.254.169.254', family: 4 }],
+      })
+    ).rejects.toThrow(/SSRF protection/)
+  })
+
+  it('allows hostnames whose DNS answers are public', async () => {
+    await expect(
+      assertSafeServerFetchTarget('http://cdn.example/img.png', {
+        lookup: async () => [{ address: '8.8.8.8', family: 4 }],
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('fails closed when DNS returns no records', async () => {
+    await expect(
+      assertSafeServerFetchTarget('http://empty.example/', {
+        lookup: async () => [],
+      })
+    ).rejects.toThrow(/Can't resolve image host/)
+  })
+})
+
+describe('safeServerFetch (redirects)', () => {
+  let server: Server | undefined
+  let base: string
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) =>
+        server!.close((err) => (err ? reject(err) : resolve()))
+      )
+      server = undefined
+    }
+  })
+
+  async function listen(
+    handler: Parameters<typeof createServer>[0]
+  ): Promise<string> {
+    server = createServer(handler)
+    await new Promise<void>((resolve) =>
+      server!.listen(0, '127.0.0.1', resolve)
+    )
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') throw new Error('no address')
+    base = `http://127.0.0.1:${addr.port}`
+    return base
+  }
+
+  it('blocks a redirect to a private address', async () => {
+    // Loopback open-redirector + stubbed DNS/fetch so hop 1 looks public
+    // while Location points at a blocked address.
+    const origin = await listen((req, res) => {
+      if (req.url === '/open') {
+        res.writeHead(302, {
+          Location: 'http://169.254.169.254/latest/meta-data/',
+        })
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'content-type': 'image/png' })
+      res.end(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    })
+
+    const publicUrl = 'http://images.example/open'
+    await expect(
+      safeServerFetch(publicUrl, {
+        lookup: async () => [{ address: '8.8.8.8', family: 4 }],
+        fetch: async (input) => {
+          const u = typeof input === 'string' ? input : String(input)
+          if (u === publicUrl || u.endsWith('/open')) {
+            return fetch(`${origin}/open`, { redirect: 'manual' })
+          }
+          return fetch(input as string, { redirect: 'manual' })
+        },
+      })
+    ).rejects.toThrow(/SSRF protection/)
+  })
+
+  it('follows a same-host redirect to a safe final URL', async () => {
+    const origin = await listen((req, res) => {
+      if (req.url === '/from') {
+        res.writeHead(302, { Location: '/to' })
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('ok')
+    })
+
+    const start = 'http://cdn.example/from'
+    const res = await safeServerFetch(start, {
+      lookup: async () => [{ address: '8.8.8.8', family: 4 }],
+      fetch: async (input) => {
+        const u = typeof input === 'string' ? input : String(input)
+        const path = new URL(u).pathname
+        return fetch(`${origin}${path}`, { redirect: 'manual' })
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('ok')
   })
 })


### PR DESCRIPTION
Strip FQDN trailing dots, block .internal hosts, validate each redirect hop, and reject hostnames that resolve to private IPs on Node.

Long term we're going to have a open source repo for SSRF safe fetches that I can migrate satori to.