### PR TITLE
feat: support `space-evenly` for justifyContent and alignContent

### DIFF
--- a/src/handler/compute.ts
+++ b/src/handler/compute.ts
@@ -194,6 +194,7 @@ export default async function compute(
         'flex-end': Yoga.ALIGN_FLEX_END,
         'space-between': Yoga.ALIGN_SPACE_BETWEEN,
         'space-around': Yoga.ALIGN_SPACE_AROUND,
+        'space-evenly': Yoga.ALIGN_SPACE_EVENLY,
         baseline: Yoga.ALIGN_BASELINE,
         normal: Yoga.ALIGN_AUTO,
       },
@@ -241,6 +242,7 @@ export default async function compute(
         'flex-end': Yoga.JUSTIFY_FLEX_END,
         'space-between': Yoga.JUSTIFY_SPACE_BETWEEN,
         'space-around': Yoga.JUSTIFY_SPACE_AROUND,
+        'space-evenly': Yoga.JUSTIFY_SPACE_EVENLY,
       },
       Yoga.JUSTIFY_FLEX_START,
       'justifyContent'

--- a/test/space-evenly.test.tsx
+++ b/test/space-evenly.test.tsx
@@ -1,0 +1,74 @@
+import { it, describe, expect } from 'vitest'
+
+import { initFonts } from './utils.js'
+import satori from '../src/index.js'
+
+// `space-evenly` is a standard value of both `justify-content` and
+// `align-content`, and Yoga implements it (JUSTIFY_SPACE_EVENLY /
+// ALIGN_SPACE_EVENLY). It was simply missing from the value maps, so it threw.
+//
+// The assertions use positions rather than an image snapshot because that is
+// what distinguishes this value from `space-around`: two 10px boxes in a 100px
+// column land at 27/63 with `space-evenly` (three equal gaps) and at 20/70 with
+// `space-around` (half-size gaps at the edges).
+describe('space-evenly', () => {
+  let fonts
+  initFonts((f) => (fonts = f))
+
+  const ys = (svg: string) =>
+    [...svg.matchAll(/y="([\d.]+)"/g)].map((m) => m[1])
+
+  it('should support justifyContent: space-evenly', async () => {
+    const column = (justifyContent: string) => (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent,
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div
+          style={{ display: 'flex', width: 10, height: 10, background: 'red' }}
+        />
+        <div
+          style={{ display: 'flex', width: 10, height: 10, background: 'red' }}
+        />
+      </div>
+    )
+    const opts = { width: 100, height: 100, fonts }
+
+    const evenly = await satori(column('space-evenly'), opts)
+    expect(ys(evenly)).toContain('27')
+    expect(ys(evenly)).toContain('63')
+
+    const around = await satori(column('space-around'), opts)
+    expect(ys(around)).toContain('20')
+    expect(ys(around)).toContain('70')
+  })
+
+  it('should support alignContent: space-evenly', async () => {
+    const svg = await satori(
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignContent: 'space-evenly',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div
+          style={{ display: 'flex', width: 100, height: 10, background: 'red' }}
+        />
+        <div
+          style={{ display: 'flex', width: 100, height: 10, background: 'red' }}
+        />
+      </div>,
+      { width: 100, height: 100, fonts }
+    )
+    expect(ys(svg)).toContain('27')
+    expect(ys(svg)).toContain('63')
+  })
+})


### PR DESCRIPTION
## Problem (#780)

`space-evenly` is a standard value of both [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) and [`align-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content), but passing it throws:

```
Invalid value for CSS property "justifyContent".
Allowed values: "center" | "flex-start" | "flex-end" | "space-between" | "space-around".
Received: "space-evenly".
```

### Root cause

Two value maps in `src/handler/compute.ts` omit it, so `getYogaValueFromCSS` rejects the value. Yoga itself already implements it: `Yoga.JUSTIFY_SPACE_EVENLY` and `Yoga.ALIGN_SPACE_EVENLY` both exist and were simply never mapped.

### Fix

One entry per map:

```diff
   'space-between': Yoga.JUSTIFY_SPACE_BETWEEN,
   'space-around': Yoga.JUSTIFY_SPACE_AROUND,
+  'space-evenly': Yoga.JUSTIFY_SPACE_EVENLY,
```

```diff
   'space-between': Yoga.ALIGN_SPACE_BETWEEN,
   'space-around': Yoga.ALIGN_SPACE_AROUND,
+  'space-evenly': Yoga.ALIGN_SPACE_EVENLY,
```

## Tests

`test/space-evenly.test.tsx` asserts positions rather than an image snapshot, because position is exactly what distinguishes this value from the one people reach for as a workaround. Two 10px boxes in a 100px column:

| `justifyContent` | y positions |
| --- | --- |
| `space-evenly` | 27, 63 (three equal gaps) |
| `space-around` | 20, 70 (half-size gaps at the edges) |
| `space-between` | 0, 90 |

Measured against this branch, not assumed. Reverting the two lines makes both tests fail with the two "Invalid value" errors quoted above.

`test/flexbox-advanced.test.tsx`, `test/gap.test.tsx` and `test/layout.test.tsx` still pass (26 tests).

## Notes

The change is additive: no existing value changes meaning, and the default (`JUSTIFY_FLEX_START` / `ALIGN_AUTO`) is untouched. 