### PR TITLE
docs: replace removed Next.js OG template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 > **Note**
 >
-> To use Satori in your project to generate PNG images like Open Graph images and social cards, check out our [announcement](https://vercel.com/blog/introducing-vercel-og-image-generation-fast-dynamic-social-card-images) and [Vercel’s Open Graph Image Generation →](https://vercel.com/docs/concepts/functions/edge-functions/og-image-generation)
+> To use Satori in your project to generate PNG images like Open Graph images and social cards, check out our [announcement](https://vercel.com/blog/introducing-vercel-og-image-generation-fast-dynamic-social-card-images) and [Vercel’s Open Graph Image Generation docs →](https://vercel.com/docs/og-image-generation)
 >
-> To use it in Next.js, take a look at the [Next.js Open Graph Image Generation template →](https://vercel.com/templates/next.js/og-image-generation)
+> To use it in Next.js, take a look at the [Open Graph Image Generation examples →](https://vercel.com/docs/og-image-generation/examples)
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- replaces the removed Next.js Open Graph Image Generation template link in the README
- updates the Vercel Open Graph Image Generation docs link to the maintained docs path
- points Next.js users to the maintained OG image examples page

Closes #692

## Validation
- `npm exec --cache "D:\grand-final prr\.cache\npm-satori" --yes --package prettier@2.7.1 -- prettier --check README.md`
- `git diff --check`