### PR TITLE
fix: bundle harfbuzzjs so consumers do not resolve the unpatched package

### DIFF
--- a/test/browser-build.mjs
+++ b/test/browser-build.mjs
@@ -26,6 +26,15 @@ for (const entry of [
         'the browser build must replace this flag at build time.'
     )
   }
+
+  if (/(?:require\(|from\s*)["']harfbuzzjs["']/.test(source)) {
+    throw new Error(
+      `${entry} imports harfbuzzjs at runtime; it must be bundled instead. ` +
+        'This repo patches harfbuzzjs to drop its Node fs branch and inline ' +
+        'hb.wasm, and that patch does not reach consumers, so leaving the ' +
+        'import external breaks every bundler.'
+    )
+  }
 }
 
 const outfile = new URL('../.tmp/browser-build.js', import.meta.url)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   minify: process.env.NODE_ENV !== 'development',
   format: ['esm', 'cjs'],
-  noExternal: ['twrnc', 'emoji-regex-xs', 'yoga-layout'],
+  noExternal: ['twrnc', 'emoji-regex-xs', 'yoga-layout', 'harfbuzzjs'],
   esbuildOptions(options) {
     options.tsconfig = 'tsconfig.json'
     options.legalComments = 'external'


### PR DESCRIPTION
fixes #791
fixes #794

`harfbuzzjs` is left external in the published bundle, so all four dist entries end up with a bare `require("harfbuzzjs")` and we ship no `hb.wasm`. whoever installs satori gets the plain package, and its loader reads `__dirname + "/hb.wasm"`. once a bundler moves that code `__dirname` isn't `node_modules/harfbuzzjs` anymore, so the wasm isn't where it looks. on a worker target it doesn't even get that far, it dies resolving `fs`.

no framework needed to see it, `npm i satori@0.33.4 esbuild` and put `dist/index.js` through esbuild with `platform: 'browser'`:

```
✘ [ERROR] Could not resolve "fs"

    node_modules/harfbuzzjs/hb.js:1:820:
      1 │ ...NMENT_IS_NODE){var fs=require("fs");scriptDirectory=__dirname+"/...
        ╵                                  ~~~~
```

with `platform: 'node'` and cjs it bundles fine and then rendering aborts, `ENOENT ... <outdir>/hb.wasm`.

ci doesn't catch either of these because `patches/harfbuzzjs@0.10.0.patch` drops the fs branch and inlines the wasm, so `test/browser-build.mjs` has only ever bundled a harfbuzzjs that was already fixed. the patch doesn't reach anyone installing satori.

so this adds `harfbuzzjs` to `noExternal` like `yoga-layout`, and makes `browser-build.mjs` fail if a dist entry still imports it. that check does fail on main, i ran it before adding it. suite still green locally, 512 tests.

the cost is size, since the wasm is in the bundle now. index.js goes from 122 to 330 KB gzipped, standalone from 83 to 291.

the standalone number is the one worth arguing about, it had no wasm inlined before this. i went this way because shaping isn't optional since 0.33 so standalone needs the wasm regardless, and this way nobody has to touch their code. if you'd rather keep standalone small the other shape is shipping `hb.wasm` as a subpath export with an `init` like yoga has, but that breaks everyone already on `satori/standalone` and i didn't want to make that call inside a bug fix. happy to redo it that way.
