### PR TITLE
fix: report http status and content type when an image fails to load

### DIFF
--- a/src/handler/image.ts
+++ b/src/handler/image.ts
@@ -210,7 +210,7 @@ function parseSvgImageSize(src: string, data: string) {
   return imageSize
 }
 
-function arrayBufferToDataUri(data: ArrayBuffer) {
+function arrayBufferToDataUri(data: ArrayBuffer, responseType?: string) {
   let imageSize: [number, number]
 
   const imageType = detectContentType(new Uint8Array(data))
@@ -232,7 +232,13 @@ function arrayBufferToDataUri(data: ArrayBuffer) {
   }
 
   if (!ALLOWED_IMAGE_TYPES.includes(imageType)) {
-    throw new Error(`Unsupported image type: ${imageType || 'unknown'}`)
+    const detail =
+      !imageType && responseType
+        ? `. The server sent Content-Type "${responseType}", which is not an image format Satori can decode.`
+        : ''
+    throw new Error(
+      `Unsupported image type: ${imageType || 'unknown'}${detail}`
+    )
   }
   return [
     `data:${imageType};base64,${arrayBufferToBase64(data)}`,
@@ -341,9 +347,19 @@ export async function resolveImageData(
     typeof window === 'undefined'
       ? () => safeServerFetch(url)
       : () => fetch(url)
+  let responseType: string | null = null
   const promise = doFetch()
     .then((res): Promise<string | ArrayBuffer> => {
       const type = res.headers.get('content-type')
+      responseType = type
+
+      if (res.ok === false) {
+        throw new Error(
+          `the server responded with ${res.status}${
+            res.statusText ? ` ${res.statusText}` : ''
+          }${type ? ` (Content-Type: "${type}")` : ''}`
+        )
+      }
 
       // Handle SVG specially
       if (type === 'image/svg+xml' || type === 'application/svg+xml') {
@@ -364,7 +380,7 @@ export async function resolveImageData(
         }
       }
 
-      const [newSrc, imageSize] = arrayBufferToDataUri(data)
+      const [newSrc, imageSize] = arrayBufferToDataUri(data, responseType)
       return [newSrc, ...imageSize] as ResolvedImageData
     })
     .then((result) => {

--- a/test/image.test.tsx
+++ b/test/image.test.tsx
@@ -1,4 +1,4 @@
-import { it, describe, expect, beforeEach, afterEach } from 'vitest'
+import { it, describe, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import { initFonts, toImage } from './utils.js'
 import satori from '../src/index.js'
@@ -1229,5 +1229,59 @@ describe('objectFit and objectPosition', () => {
       )
       expect(toImage(svg, 100)).toMatchImageSnapshot()
     })
+  })
+})
+
+describe('Image error reporting', () => {
+  async function renderRemoteImage() {
+    const errors: string[] = []
+    const spy = vi
+      .spyOn(console, 'error')
+      .mockImplementation((msg) => errors.push(String(msg)))
+    try {
+      await satori(
+        <div style={{ display: 'flex' }}>
+          <img
+            src={`https://example.com/${Math.random()}.png`}
+            width={10}
+            height={10}
+          />
+        </div>,
+        { width: 50, height: 50, fonts }
+      )
+    } finally {
+      spy.mockRestore()
+    }
+    return errors.join('\n')
+  }
+
+  it('should report the status code when the server does not return the image', async () => {
+    ;(globalThis as any).fetch = async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: { get: () => 'text/html' },
+      arrayBuffer: async () => new Uint8Array([60, 33, 100]).buffer,
+    })
+
+    const output = await renderRemoteImage()
+    expect(output).toContain('404')
+    expect(output).toContain('Not Found')
+    expect(output).not.toContain('Unsupported image type')
+  })
+
+  it('should report the content type when the response is not a decodable image', async () => {
+    ;(globalThis as any).fetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/html' },
+      arrayBuffer: async () =>
+        new Uint8Array([0x3c, 0x21, 0x64, 0x6f, 0x63, 0x74]).buffer,
+    })
+
+    const output = await renderRemoteImage()
+    expect(output).toContain('Unsupported image type')
+    expect(output).toContain('text/html')
   })
 })


### PR DESCRIPTION
fixes #613
fixes #626
refs #575

when a remote image fails to load, satori reports `Unsupported image type: unknown` no matter what actually went wrong. the response status is never checked, so a 404 html page goes straight into the magic byte sniffer, comes back as null, and the user gets told their png is an unsupported format.

that is why those three issues have gone in circles for two years. people keep saying the same thing, the image opens fine in my browser, it works in dev and not in prod. of course it does, the url is 404ing in prod and nothing in the message says so.

on 0.33.4, an existing 404 and an html page produce the exact same output:

```
Can't load image https://raw.githubusercontent.com/vercel/satori/main/definitely-not-here.png: Unsupported image type: unknown
Can't load image https://example.com/: Unsupported image type: unknown
```

after this change:

```
Can't load image https://raw.githubusercontent.com/vercel/satori/main/definitely-not-here.png: the server responded with 404 Not Found (Content-Type: "text/plain; charset=utf-8")
Can't load image https://example.com/: Unsupported image type: unknown. The server sent Content-Type "text/html", which is not an image format Satori can decode.
```

two changes. the fetch path now fails when the response was not ok and says which status came back, and when the bytes really are unrecognised the error names the content type the server sent.

i used `res.ok === false` rather than `!res.ok` on purpose. satori lets you bring your own fetch, and the test polyfill in this repo returns a bare object with no `ok` on it, so a truthiness check would have thrown on every existing image test and on anyone with a similar polyfill. this way it only fires when a response positively reports failure.

#575 reports a cdn image rendering blank without quoting an error, so i have only linked it rather than closing it. if it is the same thing this change will finally say so in the log, and if it is cors or a redirect it will say that instead.

nothing about the fallback behaviour changes. a broken image is still swallowed and the rest of the render still succeeds, you just get told why.

added two tests, one per branch. both fail on main, i checked before adding them. suite is green locally, 514 tests.
